### PR TITLE
security(config): disable display_errors in production

### DIFF
--- a/.user.ini
+++ b/.user.ini
@@ -13,3 +13,9 @@ max_input_time = 300
 ; Memory
 memory_limit = 256M
 
+; Error handling (productie: log errors, toon ze niet aan bezoekers)
+display_errors = Off
+display_startup_errors = Off
+log_errors = On
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+


### PR DESCRIPTION
## Wijzigingen
- `display_errors` uitgezet in `.user.ini` voor productie
- `log_errors` ingeschakeld zodat errors wel gelogd worden
- Voorkomt dat PHP foutmeldingen zichtbaar zijn voor bezoekers (information disclosure)

## Gewijzigde bestanden
- `.user.ini` - error handling configuratie toegevoegd

## Test plan
- [ ] Site laadt correct na wijziging
- [ ] PHP errors worden niet meer getoond aan bezoekers
- [ ] Errors worden wel gelogd in het error log

*Aangemaakt door PolitiekPraat DevTeam -- pipeline test*

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that reduces information disclosure by hiding PHP errors from users while still logging them. Potential risk is reduced debuggability if logs aren’t monitored or accessible in the target environment.
> 
> **Overview**
> Hardens production PHP configuration by turning off `display_errors`/`display_startup_errors`, enabling `log_errors`, and setting `error_reporting` to `E_ALL` excluding deprecated/strict notices to avoid leaking error details to visitors while preserving server-side logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adc3f952aa132a5c8ee39e6095db05729bb46261. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->