### PR TITLE
security(api): beperk CORS tot allowlist

### DIFF
--- a/ajax/ai-analysis.php
+++ b/ajax/ai-analysis.php
@@ -1,8 +1,8 @@
 <?php
+require_once __DIR__ . '/../includes/cors.php';
+
 header('Content-Type: application/json');
-header('Access-Control-Allow-Origin: *');
-header('Access-Control-Allow-Methods: POST');
-header('Access-Control-Allow-Headers: Content-Type');
+apply_cors_policy(['POST', 'OPTIONS'], ['Content-Type']);
 
 // Alleen POST requests toestaan
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {

--- a/ajax/ai-polling-analysis.php
+++ b/ajax/ai-polling-analysis.php
@@ -12,11 +12,11 @@ if (!defined('BASE_PATH')) {
 require_once BASE_PATH . '/includes/config.php';
 require_once BASE_PATH . '/includes/ChatGPTAPI.php';
 
+require_once BASE_PATH . '/includes/cors.php';
+
 // Headers voor JSON response
 header('Content-Type: application/json');
-header('Access-Control-Allow-Origin: *');
-header('Access-Control-Allow-Methods: POST');
-header('Access-Control-Allow-Headers: Content-Type');
+apply_cors_policy(['POST', 'OPTIONS'], ['Content-Type']);
 
 // Controleer of het een POST request is
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {

--- a/ajax/party-analysis.php
+++ b/ajax/party-analysis.php
@@ -1,8 +1,8 @@
 <?php
+require_once __DIR__ . '/../includes/cors.php';
+
 header('Content-Type: application/json');
-header('Access-Control-Allow-Origin: *');
-header('Access-Control-Allow-Methods: POST');
-header('Access-Control-Allow-Headers: Content-Type');
+apply_cors_policy(['POST', 'OPTIONS'], ['Content-Type']);
 
 // Error reporting
 error_reporting(E_ALL);

--- a/api/README.md
+++ b/api/README.md
@@ -435,7 +435,7 @@ De API heeft momenteel geen rate limiting geïmplementeerd, maar dit wordt aanbe
 
 ## CORS
 
-CORS is geconfigureerd om alle origins toe te staan. Voor productie wordt aanbevolen dit te beperken tot specifieke domains.
+CORS gebruikt een expliciete allowlist. Toegestane origins zijn standaard: `https://politiekpraat.nl`, `https://www.politiekpraat.nl`, localhost varianten voor development (`3000`, `5173`, `8000`) en zijn overschrijfbaar via `POLITIEKPRAAT_CORS_ORIGINS` (comma-separated). Niet-toegestane origins krijgen HTTP 403.
 
 ## Foutafhandeling
 

--- a/api/index.php
+++ b/api/index.php
@@ -4,17 +4,14 @@ error_reporting(E_ALL);
 ini_set('display_errors', 1);
 ini_set('log_errors', 1);
 
+require_once __DIR__ . '/../includes/cors.php';
+
 // Set headers voor API responses
 header('Content-Type: application/json; charset=UTF-8');
-header('Access-Control-Allow-Origin: *');
-header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
-header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With, X-API-Key');
-
-// Handle preflight OPTIONS request
-if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    http_response_code(200);
-    exit();
-}
+apply_cors_policy(
+    ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    ['Content-Type', 'Authorization', 'X-Requested-With', 'X-API-Key']
+);
 
 // Debug functie
 function debug_log($message) {

--- a/api/stemwijzer.php
+++ b/api/stemwijzer.php
@@ -1,8 +1,8 @@
 <?php
+require_once __DIR__ . '/../includes/cors.php';
+
 header('Content-Type: application/json');
-header('Access-Control-Allow-Origin: *');
-header('Access-Control-Allow-Methods: GET, POST');
-header('Access-Control-Allow-Headers: Content-Type');
+apply_cors_policy(['GET', 'POST', 'OPTIONS'], ['Content-Type']);
 
 // Include necessary files
 require_once '../includes/config.php';

--- a/includes/cors.php
+++ b/includes/cors.php
@@ -1,0 +1,61 @@
+<?php
+
+if (!function_exists('get_allowed_cors_origins')) {
+    function get_allowed_cors_origins(): array {
+        $envOrigins = getenv('POLITIEKPRAAT_CORS_ORIGINS');
+
+        if ($envOrigins !== false && trim($envOrigins) !== '') {
+            $origins = array_filter(array_map('trim', explode(',', $envOrigins)));
+            if (!empty($origins)) {
+                return array_values(array_unique($origins));
+            }
+        }
+
+        return [
+            'https://politiekpraat.nl',
+            'https://www.politiekpraat.nl',
+            'http://localhost:3000',
+            'http://127.0.0.1:3000',
+            'http://localhost:5173',
+            'http://127.0.0.1:5173',
+            'http://localhost:8000',
+            'http://127.0.0.1:8000'
+        ];
+    }
+}
+
+if (!function_exists('apply_cors_policy')) {
+    function apply_cors_policy(array $methods, array $headers = ['Content-Type'], bool $reject_disallowed = true): void {
+        $origin = $_SERVER['HTTP_ORIGIN'] ?? null;
+        $allowedOrigins = get_allowed_cors_origins();
+
+        header('Vary: Origin');
+        header('Access-Control-Allow-Methods: ' . implode(', ', $methods));
+        header('Access-Control-Allow-Headers: ' . implode(', ', $headers));
+
+        if ($origin === null || $origin === '') {
+            return;
+        }
+
+        if (in_array($origin, $allowedOrigins, true)) {
+            header('Access-Control-Allow-Origin: ' . $origin);
+
+            if (($_SERVER['REQUEST_METHOD'] ?? '') === 'OPTIONS') {
+                http_response_code(204);
+                exit;
+            }
+
+            return;
+        }
+
+        if ((($_SERVER['REQUEST_METHOD'] ?? '') === 'OPTIONS') || $reject_disallowed) {
+            http_response_code(403);
+            header('Content-Type: application/json; charset=UTF-8');
+            echo json_encode([
+                'success' => false,
+                'error' => 'Origin niet toegestaan'
+            ], JSON_UNESCAPED_UNICODE);
+            exit;
+        }
+    }
+}


### PR DESCRIPTION
Closes #3

## Wijzigingen
- Nieuwe gedeelde CORS-helper toegevoegd in `includes/cors.php` met expliciete allowlist.
- Wildcard CORS verwijderd uit:
  - `api/index.php`
  - `api/stemwijzer.php`
  - `ajax/party-analysis.php`
  - `ajax/ai-analysis.php`
  - `ajax/ai-polling-analysis.php`
- `Vary: Origin` toegevoegd via helper.
- Preflight (`OPTIONS`) afgehandeld met 204 voor toegestane origins.
- Onbekende origins krijgen 403 met JSON-response.
- CORS-documentatie bijgewerkt in `api/README.md` inclusief `POLITIEKPRAAT_CORS_ORIGINS` override.

## Test plan
- [x] Handmatige code-review op alle betrokken endpoints
- [ ] `php -l` op gewijzigde PHP-bestanden (niet uitvoerbaar in deze omgeving: `php` binary ontbreekt)
- [ ] Preflight request testen vanaf toegestane origin
- [ ] Request vanaf niet-toegestane origin moet 403 geven

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wijzigt CORS-gedrag van wildcard naar allowlist, wat legitieme clients kan breken als hun origin niet (correct) is geconfigureerd. Ook verandert preflight/OPTIONS-afhandeling en kan daardoor integraties beïnvloeden.
> 
> **Overview**
> Introduceert een gedeelde CORS-helper (`includes/cors.php`) met een *expliciete origin-allowlist* (override via `POLITIEKPRAAT_CORS_ORIGINS`).
> 
> Vervangt overal `Access-Control-Allow-Origin: *` door `apply_cors_policy(...)` in `api/index.php`, `api/stemwijzer.php` en meerdere `ajax/*` endpoints; toegestane preflights krijgen `204`, niet-toegestane origins krijgen `403` met JSON-error. Documentatie in `api/README.md` is bijgewerkt om de nieuwe CORS-regels te beschrijven.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2fc4e22709ccb374b4b7202788ec27369d176f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->