### PR TITLE
security(core): zet display_errors uit in productie en centraliseer foutafhandeling

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -1,8 +1,8 @@
 <?php
-// Enable error reporting voor debugging
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
-ini_set('log_errors', 1);
+require_once __DIR__ . '/../includes/error_bootstrap.php';
+if (!defined('API_DEBUG')) {
+    define('API_DEBUG', APP_DEBUG);
+}
 
 // Set headers voor API responses
 header('Content-Type: application/json; charset=UTF-8');

--- a/controllers/donatie.php
+++ b/controllers/donatie.php
@@ -1,7 +1,5 @@
 <?php
-// Error reporting for development
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
+require_once dirname(__DIR__) . '/includes/error_bootstrap.php';
 
 // Base path
 if (!defined('BASE_PATH')) {

--- a/controllers/partijen.php
+++ b/controllers/partijen.php
@@ -1,7 +1,5 @@
 <?php
-// Error reporting for development
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
+require_once dirname(__DIR__) . '/includes/error_bootstrap.php';
 
 // Base path
 if (!defined('BASE_PATH')) {

--- a/controllers/partijmeter.php
+++ b/controllers/partijmeter.php
@@ -1,15 +1,11 @@
 <?php
+require_once dirname(__DIR__) . '/includes/error_bootstrap.php';
 require_once 'includes/config.php';
 require_once 'includes/Database.php';
 require_once 'includes/StemwijzerController.php';
 
 // Debug mode - zet op true voor live debugging
-$debugMode = false;
-
-if ($debugMode) {
-    error_reporting(E_ALL);
-    ini_set('display_errors', 1);
-}
+$debugMode = APP_DEBUG;
 
 // Initialize de partijmeter controller
 $partijmeterController = new StemwijzerController();

--- a/controllers/resultaten.php
+++ b/controllers/resultaten.php
@@ -1,16 +1,12 @@
 <?php
+require_once dirname(__DIR__) . '/includes/error_bootstrap.php';
 require_once 'includes/config.php';
 require_once 'includes/Database.php';
 require_once 'includes/StemwijzerController.php';
 require_once 'includes/ChatGPTAPI.php';
 
 // Debug mode - zet op true voor live debugging
-$debugMode = false;
-
-if ($debugMode) {
-    error_reporting(E_ALL);
-    ini_set('display_errors', 1);
-}
+$debugMode = APP_DEBUG;
 
 // Haal share_id uit de URL
 $shareId = $_GET['id'] ?? '';

--- a/controllers/stemwijzer.php
+++ b/controllers/stemwijzer.php
@@ -1,15 +1,11 @@
 <?php
+require_once dirname(__DIR__) . '/includes/error_bootstrap.php';
 require_once 'includes/config.php';
 require_once 'includes/Database.php';
 require_once 'includes/StemwijzerController.php';
 
 // Debug mode - zet op true voor live debugging
-$debugMode = false;
-
-if ($debugMode) {
-    error_reporting(E_ALL);
-    ini_set('display_errors', 1);
-}
+$debugMode = APP_DEBUG;
 
 // Initialize de stemwijzer controller
 $stemwijzerController = new StemwijzerController();

--- a/includes/error_bootstrap.php
+++ b/includes/error_bootstrap.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Centrale foutafhandeling voor PolitiekPraat.
+ *
+ * Standaard draait productie veilig (geen error output naar browser).
+ * Zet APP_ENV=development of APP_DEBUG=true om debug-output lokaal toe te staan.
+ */
+
+if (!defined('APP_ENV')) {
+    $app_env = getenv('APP_ENV') ?: 'production';
+    define('APP_ENV', strtolower((string) $app_env));
+}
+
+if (!defined('APP_DEBUG')) {
+    $debug_value = getenv('APP_DEBUG');
+    $is_debug = in_array(strtolower((string) $debug_value), ['1', 'true', 'yes', 'on'], true);
+    define('APP_DEBUG', APP_ENV !== 'production' && $is_debug);
+}
+
+$logs_dir = dirname(__DIR__) . '/logs';
+if (!is_dir($logs_dir)) {
+    @mkdir($logs_dir, 0755, true);
+}
+
+ini_set('log_errors', '1');
+ini_set('error_log', $logs_dir . '/php-error.log');
+
+if (APP_DEBUG) {
+    error_reporting(E_ALL);
+    ini_set('display_errors', '1');
+    ini_set('display_startup_errors', '1');
+} else {
+    error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
+    ini_set('display_errors', '0');
+    ini_set('display_startup_errors', '0');
+}
+
+if (!function_exists('pp_is_api_request')) {
+    function pp_is_api_request(): bool
+    {
+        $uri = $_SERVER['REQUEST_URI'] ?? '';
+        return strpos($uri, '/api/') === 0 || strpos($uri, '/api') === 0;
+    }
+}
+
+if (!function_exists('pp_render_error_response')) {
+    function pp_render_error_response(string $message, int $status_code = 500): void
+    {
+        if (!headers_sent()) {
+            http_response_code($status_code);
+        }
+
+        if (pp_is_api_request()) {
+            if (!headers_sent()) {
+                header('Content-Type: application/json; charset=UTF-8');
+            }
+
+            echo json_encode([
+                'success' => false,
+                'error' => $message,
+                'timestamp' => date('c'),
+            ], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        echo APP_DEBUG
+            ? '<h1>Applicatiefout</h1><p>' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . '</p>'
+            : '<h1>Er ging iets mis</h1><p>Probeer het later opnieuw.</p>';
+    }
+}
+
+set_exception_handler(static function (Throwable $exception): void {
+    error_log(sprintf(
+        '[Uncaught Exception] %s in %s:%d\n%s',
+        $exception->getMessage(),
+        $exception->getFile(),
+        $exception->getLine(),
+        $exception->getTraceAsString()
+    ));
+
+    $message = APP_DEBUG ? $exception->getMessage() : 'Interne serverfout';
+    pp_render_error_response($message, 500);
+    exit;
+});
+
+register_shutdown_function(static function (): void {
+    $last_error = error_get_last();
+    if ($last_error === null) {
+        return;
+    }
+
+    $fatal_types = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR];
+    if (!in_array($last_error['type'], $fatal_types, true)) {
+        return;
+    }
+
+    error_log(sprintf(
+        '[Fatal Error] %s in %s:%d',
+        $last_error['message'] ?? 'Unknown fatal error',
+        $last_error['file'] ?? 'unknown',
+        $last_error['line'] ?? 0
+    ));
+
+    if (!headers_sent()) {
+        http_response_code(500);
+    }
+
+    if (!APP_DEBUG) {
+        pp_render_error_response('Interne serverfout', 500);
+    }
+});

--- a/index.php
+++ b/index.php
@@ -1,7 +1,5 @@
 <?php
-// Error reporting aanzetten
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
+require_once __DIR__ . '/includes/error_bootstrap.php';
 
 // Definieer het basis pad voor de applicatie
 $scriptDir = dirname($_SERVER['SCRIPT_FILENAME']);
@@ -27,7 +25,7 @@ require_once 'includes/CategoryController.php';
 require_once 'controllers/blogs.php';  // Add BlogsController
 
 // Debug informatie (tijdelijk)
-if (isset($_GET['debug'])) {
+if (APP_DEBUG && isset($_GET['debug'])) {
     echo "<pre>";
     echo "REQUEST_URI: " . $_SERVER['REQUEST_URI'] . "\n";
     echo "URLROOT: " . URLROOT . "\n";
@@ -188,7 +186,7 @@ try {
     require_once BASE_PATH . "/controllers/404.php";
 }
 
-if (isset($_GET['debug'])) {
+if (APP_DEBUG && isset($_GET['debug'])) {
     echo "<pre>";
     echo "Script Dir: " . $scriptDir . "\n";
     echo "Base Path: " . BASE_PATH . "\n";

--- a/php.ini
+++ b/php.ini
@@ -13,10 +13,11 @@ max_input_time = 300
 ; Memory
 memory_limit = 256M
 
-; Error Reporting (for development)
-display_errors = On
-display_startup_errors = On
-error_reporting = E_ALL
+; Error Reporting (production-safe defaults)
+display_errors = Off
+display_startup_errors = Off
+log_errors = On
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 
 ; Session
 session.gc_maxlifetime = 1440


### PR DESCRIPTION
Closes #4

## Wijzigingen
- Centrale foutconfiguratie toegevoegd in `includes/error_bootstrap.php` met productie-veilige defaults (`display_errors=0`, `log_errors=1`, logging naar `logs/php-error.log`).
- Entrypoints (`index.php`, `api/index.php`, `controllers/partijen.php`, `controllers/donatie.php`) gebruiken nu de centrale bootstrap in plaats van lokale `display_errors=1` instellingen.
- Debug output in `index.php` is nu alleen actief met `APP_DEBUG`.
- `controllers/stemwijzer.php`, `controllers/resultaten.php` en `controllers/partijmeter.php` koppelen debugmodus aan `APP_DEBUG` i.p.v. losse error ini overrides.
- `php.ini` aangepast naar productie-veilige error instellingen.
- Basale centrale exception/fatal error afhandeling toegevoegd zodat productie geen stacktraces of paden rendert.

## Test plan
- [ ] `php -l` op alle gewijzigde PHP-bestanden
- [ ] Homepage en controller-routes laden zonder PHP output van interne errors
- [ ] API geeft bij fouten een generieke JSON-fout zonder stacktrace

## Opmerking
- `php` binary is niet beschikbaar in deze omgeving, daardoor kon `php -l` hier niet lokaal uitgevoerd worden.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches application/API entrypoints and global error handling; misconfiguration could hide useful diagnostics or change error response behavior, though changes are largely additive and aimed at safer production defaults.
> 
> **Overview**
> Adds a central `includes/error_bootstrap.php` that derives `APP_ENV`/`APP_DEBUG` from environment variables, configures production-safe `display_errors`/logging, and installs global exception + fatal-error handlers that return JSON for API routes.
> 
> Updates key entrypoints (`index.php`, `api/index.php`, and several controllers) to use this bootstrap instead of ad-hoc `error_reporting`/`ini_set` calls, and gates existing `?debug` output + controller debug modes behind `APP_DEBUG`. Also changes `php.ini` defaults to disable error display and enable logging in line with production behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 532a494f5dc51bb1e35c3cd9fcbb67448637e23d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->