### PR TITLE
fix(home): hero blogimage bug + canonical redirect + veilige image URL-resolutie

### DIFF
--- a/controllers/home.php
+++ b/controllers/home.php
@@ -32,6 +32,13 @@ function stripMarkdown($text) {
     return $text;
 }
 
+// Force canonical homepage URL: /home -> / (SEO duplicate content prevention)
+$requestPath = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?? '/';
+if (rtrim($requestPath, '/') === '/home') {
+    header('Location: ' . URLROOT . '/', true, 301);
+    exit;
+}
+
 // PERFORMANCE TODO: Implement server-side caching (e.g., Redis, Memcached) for database queries and API responses to significantly improve TTFB (Time To First Byte).
 $db = new Database();
 $newsAPI = new NewsAPI();
@@ -698,14 +705,20 @@ require_once 'views/templates/header.php';
                                     </div>
                                     <!-- Blog afbeelding -->
                                     <?php if (!empty($latestBlog->image_path)): ?>
-                                        <div class="aspect-video overflow-hidden relative">
-                                            <img src="<?php echo URLROOT . '/' . $latestBlog->image_path; ?>" 
-                                                 alt="<?php echo htmlspecialchars($latestBlog->title); ?>"
-                                                 class="w-full h-full object-cover transition-transform duration-500 hover:scale-110">
-                                            
-                                            <!-- Gradient overlay voor betere tekst leesbaarheid -->
-                                            <div class="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent"></div>
-                                        </div>
+                                        <?php $heroImageUrl = getBlogImageUrl($latestBlog->image_path); ?>
+                                        <?php if (!empty($heroImageUrl)): ?>
+                                            <div class="aspect-video overflow-hidden relative">
+                                                <img src="<?php echo htmlspecialchars($heroImageUrl); ?>" 
+                                                     alt="<?php echo htmlspecialchars($latestBlog->title); ?>"
+                                                     class="w-full h-full object-cover transition-transform duration-500 hover:scale-110"
+                                                     fetchpriority="high"
+                                                     decoding="async"
+                                                     onerror="this.onerror=null;this.src='<?php echo URLROOT; ?>/metadata-foto.png';">
+                                                
+                                                <!-- Gradient overlay voor betere tekst leesbaarheid -->
+                                                <div class="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent"></div>
+                                            </div>
+                                        <?php endif; ?>
                                     <?php endif; ?>
                                     
                                     <!-- Blog content -->

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -66,24 +66,50 @@ if (!function_exists('getBlogImageUrl')) {
      * @return string|null The full URL to the image or null if no image
      */
     function getBlogImageUrl($imagePath) {
-        if (empty($imagePath)) {
+        if (empty($imagePath) || !is_string($imagePath)) {
             return null;
         }
-        
-        // If path already starts with http:// or https://, return as is
-        if (preg_match('/^https?:\/\//', $imagePath)) {
+
+        $imagePath = trim($imagePath);
+        if ($imagePath === '') {
+            return null;
+        }
+
+        // Reject unsafe schemes explicitly
+        if (preg_match('/^(javascript|data|vbscript):/i', $imagePath)) {
+            return null;
+        }
+
+        // Allow only HTTP(S) for external URLs
+        if (preg_match('/^https?:\/\//i', $imagePath)) {
             return $imagePath;
         }
-        
-        // Remove any leading slash to normalize the path
-        $imagePath = ltrim($imagePath, '/');
-        
-        // Check if the file exists
-        if (file_exists(BASE_PATH . '/' . $imagePath)) {
-            return URLROOT . '/' . $imagePath;
+
+        // Reject absolute URLs with unsupported schemes
+        if (preg_match('/^[a-z][a-z0-9+.-]*:\/\//i', $imagePath)) {
+            return null;
         }
-        
-        // If file doesn't exist, still return the expected path for backwards compatibility
+
+        // Normalize internal path and block traversal/null byte attempts
+        $imagePath = ltrim($imagePath, '/');
+        if (strpos($imagePath, "\0") !== false || strpos($imagePath, '..') !== false) {
+            return null;
+        }
+
+        $candidatePaths = [
+            $imagePath,
+            'public/' . $imagePath,
+            'public/images/' . basename($imagePath),
+            'uploads/blogs/images/' . basename($imagePath),
+        ];
+
+        foreach ($candidatePaths as $candidatePath) {
+            if (file_exists(BASE_PATH . '/' . $candidatePath)) {
+                return URLROOT . '/' . ltrim($candidatePath, '/');
+            }
+        }
+
+        // Backwards compatibility fallback for relative paths that look safe
         return URLROOT . '/' . $imagePath;
     }
 }


### PR DESCRIPTION
Closes #10
Closes #11
Closes #12

## Wijzigingen
- Home hero gebruikt nu `getBlogImageUrl()` i.p.v. harde `URLROOT` concatenatie.
- Hero image krijgt veilige fallback (`/metadata-foto.png`) bij load-fout.
- SEO-fix: 301 redirect toegevoegd van `/home` naar `/` om duplicate-content te voorkomen.
- `getBlogImageUrl()` gehard:
  - blokkeert onveilige schema's (`javascript:`, `data:`, `vbscript:`)
  - weigert traversal/null-byte paden
  - ondersteunt robuuste padresolutie voor legacy locaties (`public/images`, uploads)

## Testplan
- [x] Diff gecontroleerd op regressierisico
- [x] Bevestigd dat hero geen `https://politiekpraat.nl/https://...` meer rendert in codepad
- [x] Bevestigd dat `/home` requestpad nu 301-route neemt
- [ ] Live verify na deploy: hero afbeelding zichtbaar
- [ ] Live verify na deploy: `curl -I https://politiekpraat.nl/home` geeft 301 naar `/`

## Risico
Laag tot medium (wijzigt centrale image helper). Mitigatie: helper behoudt backwards fallback voor veilige relatieve paden.
