### PR TITLE
fix(api): herstel contract voor /api/endpoints/parties met alias

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -184,6 +184,10 @@ class APIRouter {
                 case 'partijen':
                     $this->handleParties($segments);
                     break;
+
+                case 'endpoints':
+                    $this->handleLegacyEndpointsAlias($segments);
+                    break;
                     
                 case 'forum':
                     $this->handleForum($segments);
@@ -417,6 +421,21 @@ class APIRouter {
         $this->requireEndpoint('parties');
         $partiesAPI = new PartiesAPI();
         $partiesAPI->handle($this->method, $segments);
+    }
+
+    /**
+     * Backward-compatible alias voor legacy calls zoals /api/endpoints/parties.
+     */
+    private function handleLegacyEndpointsAlias($segments) {
+        $legacyEndpoint = $segments[1] ?? '';
+
+        if ($legacyEndpoint === 'parties' || $legacyEndpoint === 'partijen') {
+            $forwardedSegments = array_slice($segments, 1);
+            $this->handleParties($forwardedSegments);
+            return;
+        }
+
+        sendApiError('Legacy endpoint niet gevonden: endpoints/' . $legacyEndpoint, 404);
     }
     
     private function handleForum($segments) {

--- a/scripts/tests/test-api-contract-parties.sh
+++ b/scripts/tests/test-api-contract-parties.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-https://politiekpraat.nl}"
+ENDPOINTS=(
+  "/api/parties"
+  "/api/endpoints/parties"
+)
+
+fail=0
+for endpoint in "${ENDPOINTS[@]}"; do
+  url="${BASE_URL}${endpoint}"
+  tmp_body="$(mktemp)"
+  status=$(curl -sS -o "$tmp_body" -w "%{http_code}" "$url" || true)
+
+  if [[ "$status" != "200" ]]; then
+    echo "FAIL: $url gaf status $status"
+    fail=1
+    rm -f "$tmp_body"
+    continue
+  fi
+
+  if ! python3 - "$tmp_body" <<'PY'
+import json, sys
+body_path = sys.argv[1]
+with open(body_path, 'r', encoding='utf-8') as f:
+    data = json.load(f)
+if not isinstance(data, dict):
+    raise SystemExit(1)
+if data.get('success') is not True:
+    raise SystemExit(1)
+payload = data.get('data', {})
+if not isinstance(payload, dict) or 'parties' not in payload:
+    raise SystemExit(1)
+print(f"OK: parties={len(payload.get('parties', []))}")
+PY
+  then
+    echo "FAIL: $url gaf geen geldig parties contract"
+    fail=1
+  else
+    echo "PASS: $url"
+  fi
+
+  rm -f "$tmp_body"
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "Contract smoke test gefaald"
+  exit 1
+fi
+
+echo "Contract smoke test geslaagd"


### PR DESCRIPTION
## Context
`GET /api/endpoints/parties` gaf 404 terwijl clients deze legacy-route nog gebruiken.

## Wijzigingen
- Backward-compatible alias toegevoegd in `api/index.php`:
  - `/api/endpoints/parties` -> handler van `/api/parties`
  - `/api/endpoints/partijen` -> handler van `/api/partijen`
- Lichte contract smoke check toegevoegd:
  - `scripts/tests/test-api-contract-parties.sh`
  - Valideert voor beide routes: HTTP 200 + JSON contract (`success=true` en `data.parties` aanwezig)

## Test plan
- [x] `./scripts/tests/test-api-contract-parties.sh https://politiekpraat.nl` uitgevoerd (verwacht nu nog fail op legacy route tot deploy)
- [x] Diff gecontroleerd op backward compatibility
