### PR TITLE
refactor(controllers): eerste veilige split van partijen-controller

### DIFF
--- a/controllers/partijen.php
+++ b/controllers/partijen.php
@@ -10,6 +10,7 @@ if (!defined('BASE_PATH')) {
 require_once BASE_PATH . '/includes/config.php';
 require_once BASE_PATH . '/includes/Database.php';
 require_once BASE_PATH . '/includes/functions.php';
+require_once BASE_PATH . '/includes/party_color_helpers.php';
 
 // Start session if not already started
 if (session_status() === PHP_SESSION_NONE) {
@@ -2332,52 +2333,6 @@ document.addEventListener('DOMContentLoaded', function() {
         return '#' + toHex(newR) + toHex(newG) + toHex(newB);
     }
 });
-
-// Helper function for PHP to use the same color mapping
-<?php
-function getPartyColor($partyKey) {
-    $partyColors = [
-        'PVV' => '#0078D7',
-        'VVD' => '#FF9900',
-        'NSC' => '#4D7F78',
-        'BBB' => '#95c119',
-        'GL-PvdA' => '#008800',
-        'D66' => '#00B13C',
-        'SP' => '#EE0000',
-        'PvdD' => '#007E3A',
-        'CDA' => '#1E8449',
-        'JA21' => '#0066CC',
-        'SGP' => '#FF6600',
-        'FvD' => '#811E1E',
-        'DENK' => '#00b7b2',
-        'Volt' => '#502379',
-        'CU' => '#00AEEF'
-    ];
-    
-    return isset($partyColors[$partyKey]) ? $partyColors[$partyKey] : '#A0A0A0';
-}
-
-// New helper function to adjust color opacity for standpoint badges
-function adjustColorOpacity($hex, $opacity) {
-    // Convert hex to rgb
-    list($r, $g, $b) = sscanf($hex, "#%02x%02x%02x");
-    return "rgba($r, $g, $b, $opacity)";
-}
-
-// New helper function to adjust color brightness
-function adjustColorBrightness($hex, $steps) {
-    // Convert hex to rgb
-    list($r, $g, $b) = sscanf($hex, "#%02x%02x%02x");
-    
-    // Adjust brightness
-    $r = max(0, min(255, $r + $steps));
-    $g = max(0, min(255, $g + $steps));
-    $b = max(0, min(255, $b + $steps));
-    
-    // Convert back to hex
-    return sprintf("#%02x%02x%02x", $r, $g, $b);
-}
-?>
 
 // Completely Rebuilt Modern Coalition Maker - Tap/Click Only
 document.addEventListener('DOMContentLoaded', function() {

--- a/includes/party_color_helpers.php
+++ b/includes/party_color_helpers.php
@@ -1,0 +1,44 @@
+<?php
+
+if (!function_exists('getPartyColor')) {
+    function getPartyColor($partyKey) {
+        $partyColors = [
+            'PVV' => '#0078D7',
+            'VVD' => '#FF9900',
+            'NSC' => '#4D7F78',
+            'BBB' => '#95c119',
+            'GL-PvdA' => '#008800',
+            'D66' => '#00B13C',
+            'SP' => '#EE0000',
+            'PvdD' => '#007E3A',
+            'CDA' => '#1E8449',
+            'JA21' => '#0066CC',
+            'SGP' => '#FF6600',
+            'FvD' => '#811E1E',
+            'DENK' => '#00b7b2',
+            'Volt' => '#502379',
+            'CU' => '#00AEEF'
+        ];
+
+        return isset($partyColors[$partyKey]) ? $partyColors[$partyKey] : '#A0A0A0';
+    }
+}
+
+if (!function_exists('adjustColorOpacity')) {
+    function adjustColorOpacity($hex, $opacity) {
+        list($r, $g, $b) = sscanf($hex, "#%02x%02x%02x");
+        return "rgba($r, $g, $b, $opacity)";
+    }
+}
+
+if (!function_exists('adjustColorBrightness')) {
+    function adjustColorBrightness($hex, $steps) {
+        list($r, $g, $b) = sscanf($hex, "#%02x%02x%02x");
+
+        $r = max(0, min(255, $r + $steps));
+        $g = max(0, min(255, $g + $steps));
+        $b = max(0, min(255, $b + $steps));
+
+        return sprintf("#%02x%02x%02x", $r, $g, $b);
+    }
+}


### PR DESCRIPTION
Closes #6 (kleine, veilige eerste slice)

## Wat is opgesplitst
- 3 pure PHP helper-functies uit `controllers/partijen.php` verplaatst naar nieuw bestand:
  - `includes/party_color_helpers.php`
  - `getPartyColor()`
  - `adjustColorOpacity()`
  - `adjustColorBrightness()`
- `controllers/partijen.php` include't nu deze helperfile.

## Waarom dit laag risico is
- Geen businesslogica gewijzigd.
- Alleen codeverplaatsing + include.
- Bestaande functie-signatures zijn gelijk gebleven.

## Test plan
- [x] Handmatige diff-check: alleen extractie/verplaatsing
- [x] Geen route/API contract wijzigingen in deze PR
