### PR TITLE
chore(repo): herstel gitignore-hygiëne voor systeemrommel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IDE en systeem bestanden
 .DS_Store
+**/.DS_Store
 .idea/
 .vscode/
 
@@ -34,5 +35,8 @@ public/uploads/profile_photos/*
 node_modules/
 
 # Sitemap (server-generated)
-sitemap.xmladmin/devteam-state.json
+sitemap.xml
+
+# Lokale devteam state
+admin/devteam-state.json
 admin/devteam-queue.json


### PR DESCRIPTION
Closes #21

## Wijzigingen
- Foutieve samengevoegde regel `sitemap.xmladmin/...` opgesplitst
- Recursieve `.DS_Store` ignore toegevoegd (`**/.DS_Store`)
- `sitemap.xml` expliciet teruggezet als aparte ignore-regel
- Lokale devteam state-bestanden expliciet onder eigen sectie

## Test plan
- [x] `git ls-files | rg 'node_modules|\.DS_Store'` geeft geen resultaat
- [x] `.gitignore` handmatig gevalideerd op syntax en intentie
