### PR TITLE
feat(stemwijzer): meta endpoint met Ede 2026 sprint context

### DIFF
--- a/api/stemwijzer.php
+++ b/api/stemwijzer.php
@@ -74,6 +74,31 @@ try {
                         'message' => 'Statistieken succesvol opgehaald'
                     ]);
                     break;
+
+                case 'meta':
+                    // Sprint 1 context-lock voor gemeentelijke stemwijzer
+                    echo json_encode([
+                        'success' => true,
+                        'scope' => [
+                            'municipality' => 'ede',
+                            'municipality_name' => 'Ede',
+                            'election' => 'gemeenteraadsverkiezingen-2026',
+                            'election_year' => 2026,
+                            'mvp_statements' => 25,
+                            'scope_locked' => true
+                        ],
+                        'features' => [
+                            'weighting_enabled' => true,
+                            'publication_authority' => 'devteam',
+                            'publication_authority_label' => 'DevTeam (Nova + team)'
+                        ],
+                        'methodology' => [
+                            'answers' => ['eens', 'neutraal', 'oneens', 'geen_mening'],
+                            'notes' => 'Weging aan; scoreberekening en transparantie worden in scoring engine v2 uitgewerkt.'
+                        ],
+                        'message' => 'Meta context succesvol opgehaald'
+                    ]);
+                    break;
                     
                 case 'results':
                     // Haal opgeslagen resultaten op via share_id


### PR DESCRIPTION
## Waarom
Voor Sprint 1 moeten frontend/admin/API exact dezelfde scope hanteren: Ede, verkiezing 2026, 25 stellingen, weging AAN en publicatie onder DevTeam.

## Wat
- Nieuwe `GET /api/stemwijzer.php?action=meta` response toegevoegd
- Endpoint geeft scope-lock en feature-flags terug:
  - gemeente `ede`
  - verkiezing `gemeenteraadsverkiezingen-2026`
  - `mvp_statements: 25`
  - `weighting_enabled: true`
  - `publication_authority: devteam`

## Risico
Laag: alleen nieuwe read-only action, geen mutaties op bestaande `data/questions/parties/...` paden.

## Test
- `bash scripts/tests/ci_smoke.sh`

Closes #30
