### PR TITLE
feat(db): gemeentelijke stemwijzer datamodel/migratie-skelet (#26)

### DIFF
--- a/database/migrations/create_gemeentelijke_stemwijzer_tables.sql
+++ b/database/migrations/create_gemeentelijke_stemwijzer_tables.sql
@@ -1,0 +1,198 @@
+-- Gemeentelijke Stemwijzer (Sprint 1 - Slice #26)
+-- Scope lock: Ede 2026, 25 stellingen, weging aan
+-- Doel: uitbreidbaar datamodel + versiebeheer, zonder bestaande landelijke stemwijzer te breken
+
+SET NAMES utf8mb4;
+
+CREATE TABLE IF NOT EXISTS municipalities (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(120) NOT NULL,
+    slug VARCHAR(160) NOT NULL,
+    province VARCHAR(120) DEFAULT NULL,
+    cbs_code VARCHAR(16) DEFAULT NULL,
+    country_code CHAR(2) NOT NULL DEFAULT 'NL',
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+    archived_at DATETIME NULL,
+    deleted_at DATETIME NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_municipalities_slug_country (slug, country_code),
+    UNIQUE KEY uq_municipalities_cbs_code (cbs_code),
+    INDEX idx_municipalities_active (is_active),
+    INDEX idx_municipalities_archived (archived_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS elections (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    election_type ENUM('gemeenteraad') NOT NULL,
+    election_scope ENUM('municipal') NOT NULL DEFAULT 'municipal',
+    election_year SMALLINT NOT NULL,
+    election_date DATE DEFAULT NULL,
+    status ENUM('draft', 'published', 'archived') NOT NULL DEFAULT 'draft',
+    title VARCHAR(180) NOT NULL,
+    description TEXT NULL,
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+    archived_at DATETIME NULL,
+    deleted_at DATETIME NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_elections_type_scope_year (election_type, election_scope, election_year),
+    INDEX idx_elections_status (status),
+    INDEX idx_elections_active (is_active),
+    INDEX idx_elections_date (election_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS election_municipalities (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    election_id INT NOT NULL,
+    municipality_id INT NOT NULL,
+    status ENUM('draft', 'published', 'archived') NOT NULL DEFAULT 'draft',
+    weighting_enabled TINYINT(1) NOT NULL DEFAULT 1,
+    expected_theses_count SMALLINT NOT NULL DEFAULT 25,
+    published_at DATETIME NULL,
+    archived_at DATETIME NULL,
+    deleted_at DATETIME NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_election_municipality (election_id, municipality_id),
+    INDEX idx_election_municipalities_status (status),
+    INDEX idx_election_municipalities_weighting (weighting_enabled),
+    CONSTRAINT fk_election_municipalities_election
+        FOREIGN KEY (election_id) REFERENCES elections(id)
+        ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT fk_election_municipalities_municipality
+        FOREIGN KEY (municipality_id) REFERENCES municipalities(id)
+        ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS election_parties (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    election_municipality_id INT NOT NULL,
+    legacy_party_id INT NULL,
+    party_name VARCHAR(120) NOT NULL,
+    party_key VARCHAR(40) NOT NULL,
+    logo_url VARCHAR(255) DEFAULT NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+    source_label VARCHAR(120) DEFAULT NULL,
+    source_url VARCHAR(255) DEFAULT NULL,
+    archived_at DATETIME NULL,
+    deleted_at DATETIME NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_election_parties_scope_key (election_municipality_id, party_key),
+    INDEX idx_election_parties_active (is_active),
+    INDEX idx_election_parties_sort (sort_order),
+    CONSTRAINT fk_election_parties_scope
+        FOREIGN KEY (election_municipality_id) REFERENCES election_municipalities(id)
+        ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT fk_election_parties_legacy
+        FOREIGN KEY (legacy_party_id) REFERENCES stemwijzer_parties(id)
+        ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS theses (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    election_municipality_id INT NOT NULL,
+    thesis_code VARCHAR(40) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NULL,
+    theme VARCHAR(120) DEFAULT NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+    archived_at DATETIME NULL,
+    deleted_at DATETIME NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_theses_scope_code (election_municipality_id, thesis_code),
+    INDEX idx_theses_scope_sort (election_municipality_id, sort_order),
+    INDEX idx_theses_active (is_active),
+    CONSTRAINT fk_theses_scope
+        FOREIGN KEY (election_municipality_id) REFERENCES election_municipalities(id)
+        ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS thesis_versions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    thesis_id INT NOT NULL,
+    version_number INT NOT NULL,
+    status ENUM('draft', 'published', 'archived') NOT NULL DEFAULT 'draft',
+    is_current TINYINT(1) NOT NULL DEFAULT 0,
+    statement_text TEXT NOT NULL,
+    context_text TEXT NULL,
+    left_label VARCHAR(120) DEFAULT NULL,
+    right_label VARCHAR(120) DEFAULT NULL,
+    change_note VARCHAR(255) DEFAULT NULL,
+    published_at DATETIME NULL,
+    archived_at DATETIME NULL,
+    deleted_at DATETIME NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_thesis_versions_number (thesis_id, version_number),
+    INDEX idx_thesis_versions_current (thesis_id, is_current),
+    INDEX idx_thesis_versions_status (status),
+    CONSTRAINT fk_thesis_versions_thesis
+        FOREIGN KEY (thesis_id) REFERENCES theses(id)
+        ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS party_positions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    election_party_id INT NOT NULL,
+    thesis_version_id INT NOT NULL,
+    position ENUM('eens', 'neutraal', 'oneens') NOT NULL,
+    weight_multiplier DECIMAL(4,2) NOT NULL DEFAULT 1.00,
+    explanation TEXT NULL,
+    source_label VARCHAR(120) DEFAULT NULL,
+    source_url VARCHAR(255) DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_party_positions_unique (election_party_id, thesis_version_id),
+    INDEX idx_party_positions_thesis_version (thesis_version_id),
+    INDEX idx_party_positions_position (position),
+    CONSTRAINT fk_party_positions_party
+        FOREIGN KEY (election_party_id) REFERENCES election_parties(id)
+        ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT fk_party_positions_thesis_version
+        FOREIGN KEY (thesis_version_id) REFERENCES thesis_versions(id)
+        ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS thesis_weights (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    thesis_version_id INT NOT NULL,
+    weight_value TINYINT UNSIGNED NOT NULL DEFAULT 1,
+    weighting_enabled TINYINT(1) NOT NULL DEFAULT 1,
+    rationale VARCHAR(255) DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_thesis_weights_version (thesis_version_id),
+    INDEX idx_thesis_weights_enabled (weighting_enabled),
+    CONSTRAINT fk_thesis_weights_version
+        FOREIGN KEY (thesis_version_id) REFERENCES thesis_versions(id)
+        ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Koppeling naar bestaande opgeslagen resultaten zonder breaking schema changes op stemwijzer_results
+CREATE TABLE IF NOT EXISTS stemwijzer_result_contexts (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    stemwijzer_result_id INT NOT NULL,
+    election_municipality_id INT NULL,
+    thesis_version_id INT NULL,
+    weighting_enabled TINYINT(1) NOT NULL DEFAULT 1,
+    context_payload JSON NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_stemwijzer_result_context_result (stemwijzer_result_id),
+    INDEX idx_stemwijzer_result_context_scope (election_municipality_id),
+    INDEX idx_stemwijzer_result_context_version (thesis_version_id),
+    CONSTRAINT fk_stemwijzer_result_context_result
+        FOREIGN KEY (stemwijzer_result_id) REFERENCES stemwijzer_results(id)
+        ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_stemwijzer_result_context_scope
+        FOREIGN KEY (election_municipality_id) REFERENCES election_municipalities(id)
+        ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT fk_stemwijzer_result_context_version
+        FOREIGN KEY (thesis_version_id) REFERENCES thesis_versions(id)
+        ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database/migrations/seed_gemeente_ede_2026_example.sql
+++ b/database/migrations/seed_gemeente_ede_2026_example.sql
@@ -1,0 +1,96 @@
+-- Voorbeeld seed voor Gemeentelijke Stemwijzer Ede 2026 (MVP)
+-- Doel: 1 gemeente + 1 verkiezing + 1 stellingversie + sample partijpositie + weging
+
+SET NAMES utf8mb4;
+
+INSERT INTO municipalities (name, slug, province, cbs_code, country_code, is_active)
+VALUES ('Ede', 'ede', 'Gelderland', '0228', 'NL', 1)
+ON DUPLICATE KEY UPDATE
+    name = VALUES(name),
+    province = VALUES(province),
+    updated_at = CURRENT_TIMESTAMP;
+
+INSERT INTO elections (election_type, election_scope, election_year, election_date, status, title, description, is_active)
+VALUES ('gemeenteraad', 'municipal', 2026, '2026-03-18', 'draft', 'Gemeenteraadsverkiezingen 2026', 'Gemeentelijke stemwijzer scope-lock: Ede 2026', 1)
+ON DUPLICATE KEY UPDATE
+    election_date = VALUES(election_date),
+    status = VALUES(status),
+    title = VALUES(title),
+    description = VALUES(description),
+    updated_at = CURRENT_TIMESTAMP;
+
+INSERT INTO election_municipalities (election_id, municipality_id, status, weighting_enabled, expected_theses_count)
+SELECT e.id, m.id, 'draft', 1, 25
+FROM elections e
+JOIN municipalities m ON m.slug = 'ede' AND m.country_code = 'NL'
+WHERE e.election_type = 'gemeenteraad' AND e.election_scope = 'municipal' AND e.election_year = 2026
+ON DUPLICATE KEY UPDATE
+    weighting_enabled = VALUES(weighting_enabled),
+    expected_theses_count = VALUES(expected_theses_count),
+    updated_at = CURRENT_TIMESTAMP;
+
+INSERT INTO election_parties (election_municipality_id, party_name, party_key, sort_order, is_active, source_label)
+SELECT em.id, 'Voorbeeld Partij Ede', 'VPE', 1, 1, 'seed-example'
+FROM election_municipalities em
+JOIN elections e ON e.id = em.election_id
+JOIN municipalities m ON m.id = em.municipality_id
+WHERE e.election_type = 'gemeenteraad' AND e.election_year = 2026 AND m.slug = 'ede'
+ON DUPLICATE KEY UPDATE
+    party_name = VALUES(party_name),
+    sort_order = VALUES(sort_order),
+    is_active = VALUES(is_active),
+    updated_at = CURRENT_TIMESTAMP;
+
+INSERT INTO theses (election_municipality_id, thesis_code, title, description, theme, sort_order, is_active)
+SELECT em.id, 'EDE-2026-001', 'Er moeten meer betaalbare woningen in Ede komen.', 'Seed-stelling voor technische validatie van versiebeheer.', 'Wonen', 1, 1
+FROM election_municipalities em
+JOIN elections e ON e.id = em.election_id
+JOIN municipalities m ON m.id = em.municipality_id
+WHERE e.election_type = 'gemeenteraad' AND e.election_year = 2026 AND m.slug = 'ede'
+ON DUPLICATE KEY UPDATE
+    title = VALUES(title),
+    description = VALUES(description),
+    theme = VALUES(theme),
+    updated_at = CURRENT_TIMESTAMP;
+
+INSERT INTO thesis_versions (thesis_id, version_number, status, is_current, statement_text, context_text, left_label, right_label, change_note, published_at)
+SELECT t.id, 1, 'draft', 1,
+       'De gemeente Ede moet extra investeren in betaalbare woningbouw.',
+       'Technische seedversie voor Sprint 1 datamodelvalidatie.',
+       'Oneens', 'Eens', 'Initiële seedversie', NULL
+FROM theses t
+JOIN election_municipalities em ON em.id = t.election_municipality_id
+JOIN elections e ON e.id = em.election_id
+JOIN municipalities m ON m.id = em.municipality_id
+WHERE t.thesis_code = 'EDE-2026-001' AND e.election_year = 2026 AND m.slug = 'ede'
+ON DUPLICATE KEY UPDATE
+    statement_text = VALUES(statement_text),
+    context_text = VALUES(context_text),
+    is_current = VALUES(is_current),
+    updated_at = CURRENT_TIMESTAMP;
+
+INSERT INTO thesis_weights (thesis_version_id, weight_value, weighting_enabled, rationale)
+SELECT tv.id, 2, 1, 'MVP-voorbeeldweging actief voor Ede 2026'
+FROM thesis_versions tv
+JOIN theses t ON t.id = tv.thesis_id
+WHERE t.thesis_code = 'EDE-2026-001' AND tv.version_number = 1
+ON DUPLICATE KEY UPDATE
+    weight_value = VALUES(weight_value),
+    weighting_enabled = VALUES(weighting_enabled),
+    rationale = VALUES(rationale),
+    updated_at = CURRENT_TIMESTAMP;
+
+INSERT INTO party_positions (election_party_id, thesis_version_id, position, weight_multiplier, explanation, source_label)
+SELECT ep.id, tv.id, 'eens', 1.00, 'Voorbeeldstandpunt voor datamodel-validatie.', 'seed-example'
+FROM election_parties ep
+JOIN election_municipalities em ON em.id = ep.election_municipality_id
+JOIN elections e ON e.id = em.election_id
+JOIN municipalities m ON m.id = em.municipality_id
+JOIN theses t ON t.election_municipality_id = em.id AND t.thesis_code = 'EDE-2026-001'
+JOIN thesis_versions tv ON tv.thesis_id = t.id AND tv.version_number = 1
+WHERE ep.party_key = 'VPE' AND e.election_year = 2026 AND m.slug = 'ede'
+ON DUPLICATE KEY UPDATE
+    position = VALUES(position),
+    weight_multiplier = VALUES(weight_multiplier),
+    explanation = VALUES(explanation),
+    updated_at = CURRENT_TIMESTAMP;

--- a/docs/gemeentelijke-stemwijzer/erd.md
+++ b/docs/gemeentelijke-stemwijzer/erd.md
@@ -1,0 +1,48 @@
+# ERD - Gemeentelijke Stemwijzer (Ede 2026 MVP)
+
+Scope: **Ede**, **gemeenteraadsverkiezingen 2026**, **25 stellingen**, **weging aan**.
+
+## Entiteiten
+
+- `municipalities`
+- `elections`
+- `election_municipalities`
+- `election_parties`
+- `theses`
+- `thesis_versions`
+- `party_positions`
+- `thesis_weights`
+- `stemwijzer_result_contexts` (koppelt bestaande `stemwijzer_results` aan datasetversie/context)
+
+## Relaties (hoog niveau)
+
+```text
+municipalities (1) ----< (N) election_municipalities (N) >---- (1) elections
+
+ election_municipalities (1) ----< (N) election_parties
+ election_municipalities (1) ----< (N) theses
+
+ theses (1) ----< (N) thesis_versions
+ thesis_versions (1) ----< (1) thesis_weights
+
+ election_parties (1) ----< (N) party_positions (N) >---- (1) thesis_versions
+
+ stemwijzer_results (1) ----< (1) stemwijzer_result_contexts
+ election_municipalities (1) ----< (N) stemwijzer_result_contexts
+ thesis_versions (1) ----< (N) stemwijzer_result_contexts
+```
+
+## Backward compatibility ontwerp
+
+- De bestaande landelijke stemwijzer-tabellen (`stemwijzer_questions`, `stemwijzer_parties`, `stemwijzer_positions`, `stemwijzer_results`) blijven intact.
+- Nieuwe gemeentelijke structuur staat volledig naast het huidige model.
+- Resultaatversie-koppeling is toegevoegd via **nieuwe** tabel `stemwijzer_result_contexts` in plaats van breaking alters op `stemwijzer_results`.
+
+## Query-paden (geïndexeerd)
+
+- Verkiezing + gemeente context: `elections` + `election_municipalities` (unique/index)
+- Stellingen volgorde binnen scope: `theses (election_municipality_id, sort_order)`
+- Actieve/publiceerde versie: `thesis_versions (thesis_id, is_current)` + `status`
+- Standpunten lookup: `party_positions (election_party_id, thesis_version_id)` (unique)
+- Weging lookup: `thesis_weights (thesis_version_id)` (unique)
+- Resultaten reproduceren: `stemwijzer_result_contexts` op `stemwijzer_result_id`, `thesis_version_id`, `election_municipality_id`

--- a/docs/gemeentelijke-stemwijzer/migratie-notes.md
+++ b/docs/gemeentelijke-stemwijzer/migratie-notes.md
@@ -1,0 +1,44 @@
+# Migratie-notes - Slice #26 (datamodel/migratie-skelet)
+
+## Doel
+Niet-brekend migratie-skelet voor gemeentelijke stemwijzercontext met versiebeheer en weging.
+
+## Toegevoegde bestanden
+
+- `database/migrations/create_gemeentelijke_stemwijzer_tables.sql`
+- `database/migrations/seed_gemeente_ede_2026_example.sql`
+- `docs/gemeentelijke-stemwijzer/erd.md`
+
+## Uitvoervolgorde
+
+1. Draai `create_gemeentelijke_stemwijzer_tables.sql`
+2. (Optioneel, test/stage) Draai `seed_gemeente_ede_2026_example.sql`
+
+## Waarom dit backward compatible is
+
+- Bestaande landelijke stemwijzer-tabellen en API-routes blijven ongemoeid.
+- Geen destructieve wijzigingen (`DROP`, `TRUNCATE`, hernoemen) op bestaande tabellen.
+- Resultaatversie-koppeling gebeurt via nieuwe tabel `stemwijzer_result_contexts`.
+
+## Rollback-notes (veilig)
+
+Alleen uitvoeren als de nieuwe gemeentelijke feature nog niet in productie gebruikt wordt.
+
+Aanbevolen volgorde i.v.m. FK's:
+
+```sql
+DROP TABLE IF EXISTS stemwijzer_result_contexts;
+DROP TABLE IF EXISTS thesis_weights;
+DROP TABLE IF EXISTS party_positions;
+DROP TABLE IF EXISTS thesis_versions;
+DROP TABLE IF EXISTS theses;
+DROP TABLE IF EXISTS election_parties;
+DROP TABLE IF EXISTS election_municipalities;
+DROP TABLE IF EXISTS elections;
+DROP TABLE IF EXISTS municipalities;
+```
+
+## Risico's
+
+- FK naar `stemwijzer_parties(id)` in `election_parties.legacy_party_id` vereist dat `stemwijzer_parties` bestaat.
+- Seed is bewust minimaal en markeert data als `draft`; geen live-impact zonder expliciete activatie/publicatie.

--- a/includes/StemwijzerController.php
+++ b/includes/StemwijzerController.php
@@ -379,6 +379,10 @@ class StemwijzerController {
             
             if ($success) {
                 $insertedId = $this->db->lastInsertId();
+
+                // Niet-brekende hook voor gemeentelijke context (optioneel)
+                $this->saveMunicipalResultContext($insertedId, $results);
+
                 error_log("StemwijzerController: saveResults - Resultaten succesvol opgeslagen met ID: " . $insertedId . ", Share ID: " . $shareId);
                 error_log("StemwijzerController: saveResults - Session: $sessionId, Antwoorden: " . count($answers) . ", User: " . ($userId ?? 'anonymous'));
                 return $shareId; // Return share_id instead of boolean for link generation
@@ -765,6 +769,66 @@ class StemwijzerController {
             
         } catch (Exception $e) {
             error_log("StemwijzerController: addShareIdColumnIfMissing - FOUT: " . $e->getMessage());
+        }
+    }
+
+    /**
+     * Sla optionele gemeentelijke context op voor reproduceerbaarheid van resultaten.
+     * Verwacht in $results: ['_municipal_context' => ['election_municipality_id' => ?, 'thesis_version_id' => ?, 'weighting_enabled' => bool, ...]]
+     */
+    private function saveMunicipalResultContext($stemwijzerResultId, $results) {
+        try {
+            if (empty($stemwijzerResultId) || !is_array($results)) {
+                return;
+            }
+
+            $municipalContext = $results['_municipal_context'] ?? null;
+            if (!is_array($municipalContext)) {
+                return; // Geen context meegegeven: niets doen (backward compatible)
+            }
+
+            $this->db->query("SHOW TABLES LIKE 'stemwijzer_result_contexts'");
+            $contextTableExists = $this->db->single();
+            if (!$contextTableExists) {
+                return;
+            }
+
+            $electionMunicipalityId = isset($municipalContext['election_municipality_id']) ? (int) $municipalContext['election_municipality_id'] : null;
+            $thesisVersionId = isset($municipalContext['thesis_version_id']) ? (int) $municipalContext['thesis_version_id'] : null;
+            $weightingEnabled = isset($municipalContext['weighting_enabled']) ? ((bool) $municipalContext['weighting_enabled'] ? 1 : 0) : 1;
+
+            $this->db->query("SELECT id FROM stemwijzer_result_contexts WHERE stemwijzer_result_id = :result_id");
+            $this->db->bind(':result_id', $stemwijzerResultId);
+            $existing = $this->db->single();
+
+            if ($existing) {
+                $this->db->query("
+                    UPDATE stemwijzer_result_contexts
+                    SET election_municipality_id = :election_municipality_id,
+                        thesis_version_id = :thesis_version_id,
+                        weighting_enabled = :weighting_enabled,
+                        context_payload = :context_payload,
+                        updated_at = NOW()
+                    WHERE stemwijzer_result_id = :result_id
+                ");
+            } else {
+                $this->db->query("
+                    INSERT INTO stemwijzer_result_contexts
+                    (stemwijzer_result_id, election_municipality_id, thesis_version_id, weighting_enabled, context_payload)
+                    VALUES
+                    (:result_id, :election_municipality_id, :thesis_version_id, :weighting_enabled, :context_payload)
+                ");
+            }
+
+            $this->db->bind(':result_id', $stemwijzerResultId);
+            $this->db->bind(':election_municipality_id', $electionMunicipalityId);
+            $this->db->bind(':thesis_version_id', $thesisVersionId);
+            $this->db->bind(':weighting_enabled', $weightingEnabled);
+            $this->db->bind(':context_payload', json_encode($municipalContext));
+            $this->db->execute();
+        } catch (Exception $e) {
+            // Nooit resultaten-opslag breken door optionele context-hook
+            error_log("StemwijzerController: saveMunicipalResultContext - FOUT: " . $e->getMessage());
         }
     }
 


### PR DESCRIPTION
Closes #26

## Wat is toegevoegd
- Nieuw migratie-skelet voor gemeentelijke stemwijzer:
  - `municipalities`
  - `elections`
  - `election_municipalities`
  - `election_parties`
  - `theses`
  - `thesis_versions`
  - `party_positions`
  - `thesis_weights`
  - `stemwijzer_result_contexts` (koppeling naar bestaande `stemwijzer_results` voor versie-reproduceerbaarheid)
- Seedvoorbeeld voor **Ede 2026** met 1 voorbeeldstelling en weging aan:
  - `database/migrations/seed_gemeente_ede_2026_example.sql`
- ERD/documentatie:
  - `docs/gemeentelijke-stemwijzer/erd.md`
  - `docs/gemeentelijke-stemwijzer/migratie-notes.md` (incl. rollback-notes)
- Minimale, niet-brekende hook in `StemwijzerController::saveResults()`:
  - optionele opslag van `_municipal_context` naar `stemwijzer_result_contexts`
  - geen wijziging aan bestaand live gedrag als context ontbreekt

## Backward compatibility
- Landelijke stemwijzer-tabellen/routes blijven intact.
- Geen destructieve schemawijzigingen op bestaande stemwijzer-tabellen.
- Nieuwe contextopslag is volledig optioneel en no-op zonder gemeentelijke payload.

## Testplan
- [x] Branch opgebouwd vanaf actuele `main`
- [x] SQL migration- en seedbestanden toegevoegd
- [x] Geen wijzigingen aan `includes/config.php`
- [x] Controller-hook is defensief (`try/catch`, no-op bij ontbreken context/tabel)
- [ ] `php -l includes/StemwijzerController.php` *(niet uitvoerbaar in deze runner: `php` binary ontbreekt)*
- [ ] Migratie draaien op stage DB en controleren dat bestaande `/stemwijzer` flow ongewijzigd werkt
- [ ] Validatiequery: opgeslagen resultaat + context rij bestaat wanneer `_municipal_context` wordt meegestuurd

## Risico-analyse
- Laag risico op regressie: wijzigingen zijn additief en guarded.
- Middel risico bij migratie-volgorde: `stemwijzer_result_contexts` verwacht bestaande `stemwijzer_results`.
- Geen deploy in deze PR: eerst samen met volgende slices batchen (#27, #29) voor 1 gecontroleerde release.
