### PR TITLE
feat(stemwijzer): scoring v2 + weging (MVP 25 stellingen) (#27)

### DIFF
--- a/api/stemwijzer.php
+++ b/api/stemwijzer.php
@@ -9,6 +9,7 @@ require_once '../includes/config.php';
 require_once '../includes/Database.php';
 require_once '../includes/StemwijzerController.php';
 require_once '../includes/ChatGPTAPI.php';
+require_once '../includes/StemwijzerScoringService.php';
 
 // Initialize controllers
 $stemwijzerController = new StemwijzerController();
@@ -94,7 +95,10 @@ try {
                         ],
                         'methodology' => [
                             'answers' => ['eens', 'neutraal', 'oneens', 'geen_mening'],
-                            'notes' => 'Weging aan; scoreberekening en transparantie worden in scoring engine v2 uitgewerkt.'
+                            'notes' => 'Scoring v2 actief: exact=1.0, neutraal-vs-uitgesproken=0.5, tegenovergesteld=0.0.',
+                            'version' => 'v2',
+                            'peildatum' => '2026-03-10',
+                            'method_link' => 'https://github.com/nandichi/PolitiekPraat/blob/main/docs/gemeentelijke-stemwijzer/legal-ethics.md'
                         ],
                         'message' => 'Meta context succesvol opgehaald'
                     ]);
@@ -216,6 +220,34 @@ try {
             $action = $_GET['action'] ?? '';
             
             switch ($action) {
+                case 'calculate-v2':
+                    $input = json_decode(file_get_contents('php://input'), true);
+
+                    if (!$input) {
+                        http_response_code(400);
+                        echo json_encode([
+                            'success' => false,
+                            'error' => 'Invalid JSON input'
+                        ]);
+                        break;
+                    }
+
+                    $answers = $input['answers'] ?? [];
+                    $weights = $input['weights'] ?? [];
+                    $minimumAnswered = max(1, (int)($input['minimum_answered'] ?? 8));
+
+                    $stemwijzerData = $stemwijzerController->getStemwijzerData();
+                    $scoringService = new StemwijzerScoringService();
+                    $scored = $scoringService->calculate($stemwijzerData['questions'] ?? [], $answers, $weights, $minimumAnswered);
+
+                    echo json_encode([
+                        'success' => true,
+                        'results' => $scored['results'],
+                        'meta' => $scored['meta'],
+                        'message' => 'Scoring v2 succesvol berekend'
+                    ]);
+                    break;
+
                 case 'save-results':
                     // Sla resultaten op
                     $input = json_decode(file_get_contents('php://input'), true);

--- a/controllers/stemwijzer.php
+++ b/controllers/stemwijzer.php
@@ -543,6 +543,11 @@ $howToStructuredData = [
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
                                             </svg>
                                         </button>
+                                        <button @click="toggleImportant()"
+                                                :class="isImportant(currentStep) ? 'bg-amber-100 text-amber-700' : 'bg-gray-100 text-gray-600'"
+                                                class="px-3 sm:px-4 py-1.5 sm:py-2 hover:bg-amber-200 rounded-full text-xs sm:text-sm font-medium transition-colors">
+                                            Belangrijk
+                                        </button>
                                         <button @click="skipQuestion()"
                                                 class="px-3 sm:px-4 py-1.5 sm:py-2 bg-gray-100 hover:bg-gray-200 rounded-full text-xs sm:text-sm font-medium text-gray-600 transition-colors">
                                             Overslaan
@@ -1165,6 +1170,8 @@ $howToStructuredData = [
                     <p class="text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed">
                         Op basis van jouw antwoorden hebben we de partijen gerangschikt die het beste bij jouw politieke voorkeuren passen.
                     </p>
+
+                    
                 </div>
 
                 <!-- Top 3 Podium -->
@@ -2377,6 +2384,9 @@ function stemwijzer() {
         aiAdviceContent: '',
         loadingAIAdvice: false,
         answers: {},
+        weights: {},
+        minimumAnsweredForReliable: 8,
+        scoringMeta: null,
         eensParties: [],
         neutraalParties: [],
         oneensParties: [],
@@ -2647,8 +2657,21 @@ function stemwijzer() {
         countAnswerType(type) {
             return Object.values(this.answers).filter(answer => answer === type).length;
         },
+
+        toggleImportant() {
+            const key = String(this.currentStep);
+            if (this.weights[key] && this.weights[key] > 1) {
+                this.weights[key] = 1;
+            } else {
+                this.weights[key] = 2;
+            }
+        },
+
+        isImportant(index) {
+            return (this.weights[String(index)] || 1) > 1;
+        },
         
-        answerQuestion(answer) {
+        async answerQuestion(answer) {
             this.answers[this.currentStep] = answer;
             
             // Add subtle haptic feedback if available
@@ -2665,22 +2688,22 @@ function stemwijzer() {
                     this.updatePartyGroups();
                 }, 300); // Small delay for smooth transition
             } else {
-                setTimeout(() => {
-                    this.calculateResults();
+                setTimeout(async () => {
+                    await this.calculateResults();
                     this.screen = 'results';
                     this.saveResultsToDatabase();
                 }, 500);
             }
         },
         
-        skipQuestion() {
+        async skipQuestion() {
             if (this.currentStep < this.totalSteps - 1) {
                 this.currentStep++;
                 this.showExplanation = false;
                 this.selectedParty = null;
                 this.updatePartyGroups();
             } else {
-                this.calculateResults();
+                await this.calculateResults();
                 this.screen = 'results';
                 this.saveResultsToDatabase();
             }
@@ -2695,54 +2718,82 @@ function stemwijzer() {
             }
         },
         
-        calculateResults() {
+        async calculateResults() {
             if (!this.questions.length) return;
-            
-            const parties = Object.keys(this.questions[0].positions);
+
+            try {
+                const response = await fetch('/api/stemwijzer.php?action=calculate-v2', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        answers: this.answers,
+                        weights: this.weights,
+                        minimum_answered: this.minimumAnsweredForReliable
+                    })
+                });
+
+                const payload = await response.json();
+                if (!payload.success || !Array.isArray(payload.results)) {
+                    throw new Error('V2 scoring niet beschikbaar');
+                }
+
+                this.scoringMeta = payload.meta || null;
+                this.finalResults = payload.results.map(row => ({
+                    name: row.name,
+                    agreement: row.agreement,
+                    rank: row.rank,
+                    logo: this.partyLogos[row.name]
+                }));
+
+                this.results = this.finalResults.reduce((acc, row) => {
+                    acc[row.name] = { agreement: row.agreement, rank: row.rank };
+                    return acc;
+                }, {});
+            } catch (error) {
+                console.error('Fallback naar lokale scoring:', error);
+                this.localCalculateResultsFallback();
+            }
+
+            this.calculatePersonalityAnalysis();
+        },
+
+        localCalculateResultsFallback() {
+            const parties = Object.keys(this.questions[0]?.positions || {});
             const results = {};
-            
+
             parties.forEach(party => {
                 results[party] = { score: 0, total: 0, agreement: 0 };
             });
-            
+
             Object.keys(this.answers).forEach(questionIndex => {
                 const question = this.questions[questionIndex];
                 const userAnswer = this.answers[questionIndex];
-                
+                if (!question || !['eens', 'neutraal', 'oneens'].includes(userAnswer)) return;
+
+                const weight = this.weights[String(questionIndex)] || 1;
                 parties.forEach(party => {
-                    const partyAnswer = question.positions[party];
-                    
-                    if (userAnswer === partyAnswer) {
-                        results[party].score += 2;
-                    } else if (
-                        (userAnswer === 'neutraal' && (partyAnswer === 'eens' || partyAnswer === 'oneens')) ||
-                        ((userAnswer === 'eens' || userAnswer === 'oneens') && partyAnswer === 'neutraal')
-                    ) {
-                        results[party].score += 1;
-                    }
-                    
-                    results[party].total += 2;
+                    const partyAnswer = question.positions?.[party];
+                    if (!['eens', 'neutraal', 'oneens'].includes(partyAnswer)) return;
+
+                    let value = 0;
+                    if (userAnswer === partyAnswer) value = 1;
+                    else if (userAnswer === 'neutraal' || partyAnswer === 'neutraal') value = 0.5;
+
+                    results[party].score += value * weight;
+                    results[party].total += weight;
                 });
             });
-            
-            // Calculate percentages
+
             parties.forEach(party => {
-                results[party].agreement = Math.round((results[party].score / results[party].total) * 100);
+                results[party].agreement = results[party].total > 0
+                    ? Math.round((results[party].score / results[party].total) * 100)
+                    : 0;
             });
-            
+
             this.results = results;
-            
-            // Create sorted array for display
             this.finalResults = parties
-                .map(party => ({
-                    name: party,
-                    agreement: results[party].agreement,
-                    logo: this.partyLogos[party]
-                }))
-                .sort((a, b) => b.agreement - a.agreement);
-                
-            // Calculate personality analysis
-            this.calculatePersonalityAnalysis();
+                .map(party => ({ name: party, agreement: results[party].agreement, logo: this.partyLogos[party] }))
+                .sort((a, b) => b.agreement - a.agreement || a.name.localeCompare(b.name));
         },
 
         calculatePersonalityAnalysis() {

--- a/includes/StemwijzerScoringService.php
+++ b/includes/StemwijzerScoringService.php
@@ -1,0 +1,128 @@
+<?php
+
+class StemwijzerScoringService
+{
+    private array $validAnswers = ['eens', 'neutraal', 'oneens'];
+
+    public function calculate(array $questions, array $answers, array $weights = [], int $minimumAnswered = 8): array
+    {
+        $partyStats = [];
+        $answeredByUser = 0;
+
+        foreach ($questions as $index => $question) {
+            $userAnswer = $answers[(string)$index] ?? $answers[$index] ?? null;
+            if ($userAnswer === 'geen_mening' || $userAnswer === 'overslaan' || !in_array($userAnswer, $this->validAnswers, true)) {
+                continue;
+            }
+
+            $positions = is_object($question) ? ($question->positions ?? []) : ($question['positions'] ?? []);
+            if (!is_array($positions)) {
+                continue;
+            }
+
+            $answeredByUser++;
+            $weight = max(1.0, (float)($weights[(string)$index] ?? $weights[$index] ?? 1));
+
+            foreach ($positions as $party => $partyAnswer) {
+                if (!in_array($partyAnswer, $this->validAnswers, true)) {
+                    continue; // partij zonder standpunt telt niet mee
+                }
+
+                if (!isset($partyStats[$party])) {
+                    $partyStats[$party] = [
+                        'weighted_score' => 0.0,
+                        'weighted_total' => 0.0,
+                        'matched' => 0,
+                        'partial' => 0,
+                        'opposed' => 0,
+                        'considered' => 0,
+                        'missing_positions' => 0
+                    ];
+                }
+
+                $match = $this->matchValue($userAnswer, $partyAnswer);
+                $partyStats[$party]['weighted_score'] += $match * $weight;
+                $partyStats[$party]['weighted_total'] += $weight;
+                $partyStats[$party]['considered']++;
+
+                if ($match === 1.0) {
+                    $partyStats[$party]['matched']++;
+                } elseif ($match === 0.5) {
+                    $partyStats[$party]['partial']++;
+                } else {
+                    $partyStats[$party]['opposed']++;
+                }
+            }
+        }
+
+        $results = [];
+        foreach ($partyStats as $party => $stat) {
+            if ($stat['weighted_total'] <= 0) {
+                continue;
+            }
+
+            $score = round(($stat['weighted_score'] / $stat['weighted_total']) * 100);
+            $results[] = [
+                'name' => $party,
+                'agreement' => $score,
+                'score' => round($stat['weighted_score'], 4),
+                'total' => round($stat['weighted_total'], 4),
+                'matched' => $stat['matched'],
+                'partial' => $stat['partial'],
+                'opposed' => $stat['opposed'],
+                'considered' => $stat['considered']
+            ];
+        }
+
+        usort($results, function ($a, $b) {
+            if ($a['agreement'] === $b['agreement']) {
+                return strcmp($a['name'], $b['name']);
+            }
+            return $b['agreement'] <=> $a['agreement'];
+        });
+
+        $rank = 1;
+        $prevScore = null;
+        foreach ($results as $i => &$row) {
+            if ($prevScore !== null && $row['agreement'] !== $prevScore) {
+                $rank = $i + 1;
+            }
+            $row['rank'] = $rank;
+            $prevScore = $row['agreement'];
+        }
+
+        return [
+            'results' => $results,
+            'meta' => [
+                'minimum_answered' => $minimumAnswered,
+                'answered_by_user' => $answeredByUser,
+                'is_reliable' => $answeredByUser >= $minimumAnswered,
+                'methodology' => [
+                    'version' => 'v2',
+                    'answers' => ['eens', 'neutraal', 'oneens', 'geen_mening'],
+                    'rules' => [
+                        'exact_match' => 1.0,
+                        'neutral_vs_expressed' => 0.5,
+                        'opposite' => 0.0,
+                        'skip_excluded' => true,
+                        'missing_party_position_excluded' => true,
+                        'weighting_enabled' => true
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    private function matchValue(string $userAnswer, string $partyAnswer): float
+    {
+        if ($userAnswer === $partyAnswer) {
+            return 1.0;
+        }
+
+        if ($userAnswer === 'neutraal' || $partyAnswer === 'neutraal') {
+            return 0.5;
+        }
+
+        return 0.0;
+    }
+}


### PR DESCRIPTION
## Samenvatting
Implementeert scoring engine v2 voor de gemeentelijke stemwijzer (Ede 2026) met weging aan, deterministische server-side berekening en backward compatible client-fallback.

## Wat is gebouwd
- Nieuwe service: `includes/StemwijzerScoringService.php`
  - exact match = 1.0
  - neutraal vs uitgesproken = 0.5
  - tegengesteld = 0.0
  - `geen_mening/overslaan` uitgesloten van noemer
  - partij zonder standpunt uitgesloten van noemer
  - tie-handling + rank
- Nieuwe endpoint: `POST /api/stemwijzer.php?action=calculate-v2`
- Frontend (`controllers/stemwijzer.php`)
  - knop "Belangrijk" per stelling (weging x2)
  - uitslagberekening primair via server (v2)
  - lokale fallback blijft beschikbaar (backward compatibility)

## Backward compatibility
- Bestaande `save-results` flow blijft intact
- Bij endpoint/probleem blijft oude client-side berekening functioneren

## Test/acceptatiecriteria
- [ ] Exacte match levert hogere score dan neutraal/tegenstelling
- [ ] Belangrijk-toggle verhoogt invloed van stelling (x2)
- [ ] `geen_mening` telt niet mee in noemer
- [ ] Partij zonder positie op stelling telt niet mee in noemer
- [ ] Tie-score geeft stabiele volgorde (alfabetisch) en correcte rank
- [ ] Resultatenpagina blijft renderen zonder regressie

## Risico
Laag tot middel: geïsoleerd binnen stemwijzer flow, met fallback ingeregeld.
