### PR TITLE
feat(stemwijzer): juridisch/ethisch transparantie + disclaimer (#29)

### DIFF
--- a/api/stemwijzer.php
+++ b/api/stemwijzer.php
@@ -95,7 +95,7 @@ try {
                         ],
                         'methodology' => [
                             'answers' => ['eens', 'neutraal', 'oneens', 'geen_mening'],
-                            'notes' => 'Scoring v2 actief: exact=1.0, neutraal-vs-uitgesproken=0.5, tegenovergesteld=0.0.',
+                            'notes' => 'Scoring v2 actief: exact=1.0, neutraal-vs-uitgesproken=0.5, tegenovergesteld=0.0. Geen stemadviesclaim.',
                             'version' => 'v2',
                             'peildatum' => '2026-03-10',
                             'method_link' => 'https://github.com/nandichi/PolitiekPraat/blob/main/docs/gemeentelijke-stemwijzer/legal-ethics.md'

--- a/controllers/stemwijzer.php
+++ b/controllers/stemwijzer.php
@@ -1171,7 +1171,7 @@ $howToStructuredData = [
                         Op basis van jouw antwoorden hebben we de partijen gerangschikt die het beste bij jouw politieke voorkeuren passen.
                     </p>
 
-                    
+                    <?php $datasetVersion = 'v2'; $peildatum = '2026-03-10'; include __DIR__ . '/../views/templates/stemwijzer-disclaimer.php'; ?>
                 </div>
 
                 <!-- Top 3 Podium -->
@@ -1561,9 +1561,9 @@ $howToStructuredData = [
                             </svg>
                         </div>
                         
-                        <h3 class="text-2xl font-bold text-gray-800 mb-4">Persoonlijk AI Stemadvies</h3>
+                        <h3 class="text-2xl font-bold text-gray-800 mb-4">AI Duiding (geen stemadvies)</h3>
                         <p class="text-lg text-gray-600 mb-6 max-w-2xl mx-auto">
-                            Krijg persoonlijk stemadvies van onze AI expert, gebaseerd op jouw unieke politieke profiel.
+                            Krijg extra duiding op je antwoorden. Dit is geen stemadvies en geen oproep om op een partij te stemmen.
                         </p>
                         
                         <!-- AI Advice Content -->
@@ -1586,7 +1586,7 @@ $howToStructuredData = [
                                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                                         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                                     </svg>
-                                    <span x-text="loadingAIAdvice ? 'AI expert analyseert jouw profiel...' : 'Krijg Persoonlijk AI Stemadvies'"></span>
+                                    <span x-text="loadingAIAdvice ? 'AI expert analyseert jouw profiel...' : 'Krijg AI Duiding (geen stemadvies)'"></span>
                                 </div>
                             </button>
                         </div>
@@ -1597,7 +1597,7 @@ $howToStructuredData = [
                                 <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                                 </svg>
-                                Dit advies is gegenereerd door AI en is bedoeld als aanvullende informatie bij je stemkeuze
+                                Deze tekst is AI-gegenereerd en uitsluitend informatief. Gebruik dit niet als stemadvies.
                             </div>
                         </div>
                     </div>

--- a/docs/gemeentelijke-stemwijzer/legal-ethics.md
+++ b/docs/gemeentelijke-stemwijzer/legal-ethics.md
@@ -1,0 +1,32 @@
+# Gemeentelijke Stemwijzer Ede 2026 - Juridisch & Ethisch kader
+
+## Doel en afbakening
+Deze stemwijzer geeft een **voorkeursovereenkomst** tussen gebruiker en partijstandpunten. Het is nadrukkelijk **geen stemadvies** en geen oproep om op een partij te stemmen.
+
+## Transparantie over methode
+- Scoring: v2 (exact = 1.0, neutraal vs uitgesproken = 0.5, tegenovergesteld = 0.0)
+- `geen_mening` / overslaan telt niet mee in de noemer
+- Partij zonder standpunt op een stelling telt niet mee in de noemer
+- Weging staat aan: gebruiker kan stellingen als belangrijk markeren
+- Server-side deterministische berekening, client toont alleen resultaat
+
+## Beperkingen
+- Bij minder dan 8 beantwoorde stellingen geldt de uitkomst als minder betrouwbaar
+- Politieke standpunten zijn contextgevoelig en kunnen wijzigen
+- Een score zegt niets over bestuurlijke kwaliteit of coalitiekansen
+
+## Brondata per stelling
+Per stelling wordt bronverwijzing bijgehouden in de dataset/methodedocumentatie. Publicatie op de uitslagpagina linkt naar deze methodepagina.
+
+## Versie en peildatum
+- Datasetversie: `v2`
+- Peildatum publicatie: `2026-03-10`
+
+## Correctiebeleid
+Onjuistheid of verouderde partijpositie melden via: **redactie@politiekpraat.nl**.
+
+Werkwijze:
+1. Melding registreren met stelling-ID en partij
+2. Redactionele controle met bronverificatie
+3. Bij gegronde melding: dataset updaten + versie/changelog bijwerken
+4. Correctie zichtbaar maken bij eerstvolgende publicatie

--- a/views/templates/stemwijzer-disclaimer.php
+++ b/views/templates/stemwijzer-disclaimer.php
@@ -1,0 +1,14 @@
+<?php
+$datasetVersion = $datasetVersion ?? 'v2';
+$peildatum = $peildatum ?? '2026-03-10';
+?>
+<div class="mt-6 max-w-4xl mx-auto text-left bg-amber-50 border border-amber-200 rounded-2xl p-4">
+    <p class="text-sm text-amber-900">
+        <strong>Belangrijk:</strong> dit is een voorkeursovereenkomst, geen stemadvies.
+        Datasetversie: <?= htmlspecialchars($datasetVersion, ENT_QUOTES, 'UTF-8') ?> ·
+        Peildatum: <?= htmlspecialchars($peildatum, ENT_QUOTES, 'UTF-8') ?>.
+        <a href="https://github.com/nandichi/PolitiekPraat/blob/main/docs/gemeentelijke-stemwijzer/legal-ethics.md" target="_blank" class="underline">Methode & juridisch kader</a> ·
+        <a href="https://github.com/nandichi/PolitiekPraat/blob/main/docs/gemeentelijke-stemwijzer/legal-ethics.md#brondata-per-stelling" target="_blank" class="underline">Bronnen per stelling</a> ·
+        Correctieverzoek: <a href="mailto:redactie@politiekpraat.nl" class="underline">redactie@politiekpraat.nl</a>
+    </p>
+</div>


### PR DESCRIPTION
## Samenvatting
Voegt juridisch/ethisch transparantie toe voor de gemeentelijke stemwijzer Ede 2026, inclusief expliciete "geen stemadvies" disclaimer en publiek methodekader.

## Wat is gebouwd
- Nieuwe documentatiepagina:
  - `docs/gemeentelijke-stemwijzer/legal-ethics.md`
  - bevat doel/afbakening, methodiek, beperkingen, versie/peildatum, correctiebeleid
- Nieuwe herbruikbare template:
  - `views/templates/stemwijzer-disclaimer.php`
- Resultatenpagina stemwijzer (`controllers/stemwijzer.php`):
  - duidelijke disclaimer: voorkeursovereenkomst, geen stemadvies
  - links naar methodepagina + bronnen-sectie + correctieverzoek
  - AI-sectie hernoemd naar duiding (geen stemadviesclaim)
- API meta (`api/stemwijzer.php?action=meta`):
  - `version`, `peildatum`, `method_link`

## Backward compatibility
- Geen breaking changes in bestaande endpoints
- Alleen extra transparantievelden en UI-copy

## Test/acceptatiecriteria
- [ ] Resultatenpagina toont expliciet "geen stemadvies"
- [ ] Link naar methodepagina werkt
- [ ] Bronnen-link en correctie-mailadres zichtbaar
- [ ] API `action=meta` bevat version/peildatum/method_link
- [ ] Bestaande stemwijzerflow blijft intact

## Risico
Laag: tekst/documentatie + beperkte UI-aanpassingen.
