### PR TITLE
refactor(api): centraliseer JWT verify-logica

### DIFF
--- a/api/endpoints/auth.php
+++ b/api/endpoints/auth.php
@@ -4,6 +4,7 @@ class AuthAPI {
     private $db;
     private $authController;
     private $secretKey;
+    private $jwtService;
     
     public function __construct() {
         $this->db = new Database();
@@ -11,6 +12,7 @@ class AuthAPI {
         
         // JWT secret key - in productie moet dit in een config file
         $this->secretKey = 'PolitiekPraat_JWT_Secret_2024_Secure_Key_' . (defined('DB_NAME') ? DB_NAME : 'default');
+        $this->jwtService = new JwtService($this->secretKey);
     }
     
     public function handle($method, $segments) {
@@ -272,30 +274,7 @@ class AuthAPI {
     }
     
     private function verifyJWT($token) {
-        $tokenParts = explode('.', $token);
-        if (count($tokenParts) !== 3) {
-            return false;
-        }
-        
-        list($header, $payload, $signature) = $tokenParts;
-        
-        // Verificeer signature
-        $expectedSignature = hash_hmac('sha256', $header . "." . $payload, $this->secretKey, true);
-        $expectedSignature = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($expectedSignature));
-        
-        if (!hash_equals($signature, $expectedSignature)) {
-            return false;
-        }
-        
-        // Decode payload
-        $payload = json_decode(base64_decode(str_replace(['-', '_'], ['+', '/'], $payload)), true);
-        
-        // Controleer expiration
-        if ($payload['exp'] < time()) {
-            return false;
-        }
-        
-        return $payload;
+        return $this->jwtService->verify($token);
     }
     
     private function getCurrentUserFromToken() {

--- a/api/endpoints/blogs.php
+++ b/api/endpoints/blogs.php
@@ -3,12 +3,12 @@
 class BlogsAPI {
     private $db;
     private $blogController;
-    private $secretKey;
+    private $jwtService;
     
     public function __construct() {
         $this->db = new Database();
         $this->blogController = new BlogController();
-        $this->secretKey = 'PolitiekPraat_JWT_Secret_2024_Secure_Key_' . (defined('DB_NAME') ? DB_NAME : 'default');
+        $this->jwtService = new JwtService();
     }
     
     public function handle($method, $segments) {
@@ -477,30 +477,7 @@ class BlogsAPI {
     }
     
     private function verifyJWT($token) {
-        $tokenParts = explode('.', $token);
-        if (count($tokenParts) !== 3) {
-            return false;
-        }
-        
-        list($header, $payload, $signature) = $tokenParts;
-        
-        // Verify signature
-        $expectedSignature = hash_hmac('sha256', $header . "." . $payload, $this->secretKey, true);
-        $expectedSignature = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($expectedSignature));
-        
-        if (!hash_equals($signature, $expectedSignature)) {
-            return false;
-        }
-        
-        // Decode payload
-        $payload = json_decode(base64_decode(str_replace(['-', '_'], ['+', '/'], $payload)), true);
-        
-        // Check expiration
-        if ($payload['exp'] < time()) {
-            return false;
-        }
-        
-        return $payload;
+        return $this->jwtService->verify($token);
     }
     
     private function getJsonInput() {

--- a/api/endpoints/user.php
+++ b/api/endpoints/user.php
@@ -2,11 +2,11 @@
 
 class UserAPI {
     private $db;
-    private $secretKey;
+    private $jwtService;
     
     public function __construct() {
         $this->db = new Database();
-        $this->secretKey = 'PolitiekPraat_JWT_Secret_2024_Secure_Key_' . (defined('DB_NAME') ? DB_NAME : 'default');
+        $this->jwtService = new JwtService();
     }
     
     public function handle($method, $segments) {
@@ -440,27 +440,7 @@ class UserAPI {
     }
     
     private function verifyJWT($token) {
-        $tokenParts = explode('.', $token);
-        if (count($tokenParts) !== 3) {
-            return false;
-        }
-        
-        list($header, $payload, $signature) = $tokenParts;
-        
-        $expectedSignature = hash_hmac('sha256', $header . "." . $payload, $this->secretKey, true);
-        $expectedSignature = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($expectedSignature));
-        
-        if (!hash_equals($signature, $expectedSignature)) {
-            return false;
-        }
-        
-        $payload = json_decode(base64_decode(str_replace(['-', '_'], ['+', '/'], $payload)), true);
-        
-        if ($payload['exp'] < time()) {
-            return false;
-        }
-        
-        return $payload;
+        return $this->jwtService->verify($token);
     }
     
     private function getJsonInput() {

--- a/api/index.php
+++ b/api/index.php
@@ -109,6 +109,7 @@ try {
         '/includes/AuthController.php',
         '/includes/CategoryController.php',
         '/includes/BlogController.php',
+        '/includes/JwtService.php',
         '/includes/helpers.php'
     ];
     

--- a/includes/JwtService.php
+++ b/includes/JwtService.php
@@ -1,0 +1,71 @@
+<?php
+
+class JwtService {
+    private $secret_key;
+
+    public function __construct($secret_key = null) {
+        if ($secret_key === null) {
+            $secret_key = 'PolitiekPraat_JWT_Secret_2024_Secure_Key_' . (defined('DB_NAME') ? DB_NAME : 'default');
+        }
+
+        $this->secret_key = $secret_key;
+    }
+
+    public function verify($token) {
+        if (!is_string($token) || trim($token) === '') {
+            return false;
+        }
+
+        $token_parts = explode('.', $token);
+        if (count($token_parts) !== 3) {
+            return false;
+        }
+
+        list($header, $payload, $signature) = $token_parts;
+
+        $expected_signature = hash_hmac('sha256', $header . '.' . $payload, $this->secret_key, true);
+        $expected_signature = $this->base64UrlEncode($expected_signature);
+
+        if (!hash_equals($signature, $expected_signature)) {
+            return false;
+        }
+
+        $decoded_payload = $this->base64UrlDecode($payload);
+        if ($decoded_payload === false) {
+            return false;
+        }
+
+        $payload_data = json_decode($decoded_payload, true);
+        if (!is_array($payload_data)) {
+            return false;
+        }
+
+        if (!isset($payload_data['exp']) || !is_numeric($payload_data['exp'])) {
+            return false;
+        }
+
+        if ((int)$payload_data['exp'] < time()) {
+            return false;
+        }
+
+        return $payload_data;
+    }
+
+    private function base64UrlEncode($data) {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    private function base64UrlDecode($data) {
+        if (!is_string($data) || $data === '') {
+            return false;
+        }
+
+        $base64 = strtr($data, '-_', '+/');
+        $padding = strlen($base64) % 4;
+        if ($padding > 0) {
+            $base64 .= str_repeat('=', 4 - $padding);
+        }
+
+        return base64_decode($base64, true);
+    }
+}


### PR DESCRIPTION
Closes #41

## Wijzigingen
- Nieuwe gedeelde `JwtService` toegevoegd in `includes/JwtService.php` als single source of truth voor token-validatie (signature + payload + expiry checks).
- `AuthAPI`, `BlogsAPI` en `UserAPI` gebruiken nu allemaal dezelfde verify-flow via `JwtService`.
- API bootstrap (`api/index.php`) laadt nu ook `includes/JwtService.php` zodat endpoints consistent dezelfde service kunnen gebruiken.

## Gewijzigde bestanden
- `includes/JwtService.php` - centrale JWT verify service
- `api/endpoints/auth.php` - verifyJWT gedelegeerd naar JwtService
- `api/endpoints/blogs.php` - verifyJWT gedelegeerd naar JwtService
- `api/endpoints/user.php` - verifyJWT gedelegeerd naar JwtService
- `api/index.php` - JwtService toegevoegd aan required includes

## Test plan
- [x] Codepad gecontroleerd: alle drie endpoints roepen nu dezelfde verify-service aan.
- [x] Handmatige validatie op regressierisico (alleen verify-pad aangepast; login token generatie intact gehouden).
- [ ] `php -l` op gewijzigde bestanden (niet uitvoerbaar in deze omgeving: `php` ontbreekt in PATH).
