### PR TITLE
fix(api): harden publieke ajax ai error handling

### DIFF
--- a/ajax/ai-polling-analysis.php
+++ b/ajax/ai-polling-analysis.php
@@ -1,67 +1,59 @@
 <?php
-// Error reporting voor development
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
-
-// Base path
 if (!defined('BASE_PATH')) {
-    define('BASE_PATH', dirname(dirname(__FILE__)));
+    define('BASE_PATH', dirname(__DIR__));
 }
 
-// Include necessary files
+require_once BASE_PATH . '/includes/error_bootstrap.php';
 require_once BASE_PATH . '/includes/config.php';
 require_once BASE_PATH . '/includes/ChatGPTAPI.php';
-
 require_once BASE_PATH . '/includes/cors.php';
 
-// Headers voor JSON response
 header('Content-Type: application/json');
 apply_cors_policy(['POST', 'OPTIONS'], ['Content-Type']);
 
-// Controleer of het een POST request is
+if (!function_exists('ai_polling_error')) {
+    function ai_polling_error(string $public_message, int $status_code = 400, ?Throwable $exception = null): void
+    {
+        if ($exception !== null) {
+            error_log(sprintf(
+                '[ajax/ai-polling-analysis] %s in %s:%d',
+                $exception->getMessage(),
+                $exception->getFile(),
+                $exception->getLine()
+            ));
+        }
+
+        http_response_code($status_code);
+        echo json_encode([
+            'success' => false,
+            'error' => $public_message,
+        ], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+}
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    http_response_code(405);
-    echo json_encode([
-        'success' => false,
-        'error' => 'Alleen POST requests toegestaan'
-    ]);
-    exit;
+    ai_polling_error('Alleen POST requests toegestaan', 405);
 }
 
 try {
-    // Lees de input data
-    $input = file_get_contents('php://input');
-    $data = json_decode($input, true);
-    
-    if (!$data || !isset($data['parties'])) {
-        throw new Exception('Ongeldige input data');
+    $payload = json_decode(file_get_contents('php://input'), true);
+    if (!is_array($payload) || !isset($payload['parties']) || !is_array($payload['parties'])) {
+        ai_polling_error('Ongeldige input data');
     }
-    
-    // Initialiseer ChatGPT API
+
     $chatgpt = new ChatGPTAPI();
-    
-    // Voer de peiling analyse uit
-    $result = $chatgpt->analyzePollingData($data['parties']);
-    
-    if ($result['success']) {
-        echo json_encode([
-            'success' => true,
-            'content' => $result['content'],
-            'timestamp' => date('Y-m-d H:i:s')
-        ]);
-    } else {
-        throw new Exception($result['error'] ?? 'AI analyse mislukt');
+    $result = $chatgpt->analyzePollingData($payload['parties']);
+
+    if (empty($result['success'])) {
+        ai_polling_error('Analyse mislukt', 502);
     }
-    
-} catch (Exception $e) {
-    http_response_code(500);
+
     echo json_encode([
-        'success' => false,
-        'error' => $e->getMessage(),
-        'debug' => [
-            'file' => $e->getFile(),
-            'line' => $e->getLine()
-        ]
-    ]);
+        'success' => true,
+        'content' => $result['content'],
+        'timestamp' => date('Y-m-d H:i:s'),
+    ], JSON_UNESCAPED_UNICODE);
+} catch (Throwable $exception) {
+    ai_polling_error('Interne serverfout', 500, $exception);
 }
-?> 

--- a/ajax/party-analysis.php
+++ b/ajax/party-analysis.php
@@ -4,179 +4,149 @@ require_once __DIR__ . '/../includes/cors.php';
 header('Content-Type: application/json');
 apply_cors_policy(['POST', 'OPTIONS'], ['Content-Type']);
 
-// Error reporting
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
-
-// Base path
 if (!defined('BASE_PATH')) {
-    define('BASE_PATH', dirname(dirname(__FILE__)));
+    define('BASE_PATH', dirname(__DIR__));
 }
 
-// Include necessary files
+require_once BASE_PATH . '/includes/error_bootstrap.php';
 require_once BASE_PATH . '/includes/config.php';
 require_once BASE_PATH . '/includes/ChatGPTAPI.php';
 require_once BASE_PATH . '/models/PartyModel.php';
 
-// Check if request is POST
-if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    http_response_code(405);
-    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
-    exit;
-}
+if (!function_exists('party_analysis_error')) {
+    function party_analysis_error(string $public_message, int $status_code = 400, ?Throwable $exception = null): void
+    {
+        if ($exception !== null) {
+            error_log(sprintf(
+                '[ajax/party-analysis] %s in %s:%d',
+                $exception->getMessage(),
+                $exception->getFile(),
+                $exception->getLine()
+            ));
+        }
 
-// Get JSON input
-$input = json_decode(file_get_contents('php://input'), true);
-
-if (!$input) {
-    echo json_encode(['success' => false, 'error' => 'Invalid JSON input']);
-    exit;
-}
-
-// Validate required fields
-if (!isset($input['type']) || !isset($input['partyKey'])) {
-    echo json_encode(['success' => false, 'error' => 'Missing required fields: type, partyKey']);
-    exit;
-}
-
-$type = $input['type']; // 'party', 'leader', 'voter_profile', 'timeline', 'question'
-$partyKey = $input['partyKey'];
-
-try {
-    // Get party data
-    $partyModel = new PartyModel();
-    $party = $partyModel->getParty($partyKey);
-    
-    if (!$party) {
-        echo json_encode(['success' => false, 'error' => 'Party not found']);
+        http_response_code($status_code);
+        echo json_encode([
+            'success' => false,
+            'error' => $public_message,
+        ], JSON_UNESCAPED_UNICODE);
         exit;
     }
-    
-    // Initialize ChatGPT API
-    $chatGPT = new ChatGPTAPI();
-    
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    party_analysis_error('Method not allowed', 405);
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input)) {
+    party_analysis_error('Invalid JSON input');
+}
+
+if (!isset($input['type'], $input['partyKey'])) {
+    party_analysis_error('Missing required fields: type, partyKey');
+}
+
+$type = (string) $input['type'];
+$party_key = (string) $input['partyKey'];
+
+try {
+    $party_model = new PartyModel();
+    $party = $party_model->getParty($party_key);
+
+    if (!$party) {
+        party_analysis_error('Party not found', 404);
+    }
+
+    $chat_gpt = new ChatGPTAPI();
+
     switch ($type) {
         case 'party':
-            // Analyze party pros and cons
-            $result = $chatGPT->analyzePartyProsAndCons($party['name'], $party);
-            
-            if (!$result['success']) {
-                echo json_encode([
-                    'success' => false, 
-                    'error' => 'Analysis API error: ' . $result['error']
-                ]);
-                exit;
+            $result = $chat_gpt->analyzePartyProsAndCons($party['name'], $party);
+            if (empty($result['success'])) {
+                party_analysis_error('Analysis failed', 502);
             }
-            
+
             echo json_encode([
                 'success' => true,
                 'type' => 'party',
                 'party_name' => $party['name'],
-                'content' => $result['content']
-            ]);
+                'content' => $result['content'],
+            ], JSON_UNESCAPED_UNICODE);
             break;
-            
+
         case 'leader':
-            // Analyze leader pros and cons
-            $result = $chatGPT->analyzeLeaderProsAndCons(
-                $party['leader'], 
-                $party['name'], 
-                $party['leader_info'], 
+            $result = $chat_gpt->analyzeLeaderProsAndCons(
+                $party['leader'],
+                $party['name'],
+                $party['leader_info'],
                 $party
             );
-            
-            if (!$result['success']) {
-                echo json_encode([
-                    'success' => false, 
-                    'error' => 'Analysis API error: ' . $result['error']
-                ]);
-                exit;
+
+            if (empty($result['success'])) {
+                party_analysis_error('Analysis failed', 502);
             }
-            
+
             echo json_encode([
                 'success' => true,
                 'type' => 'leader',
                 'leader_name' => $party['leader'],
                 'party_name' => $party['name'],
-                'content' => $result['content']
-            ]);
+                'content' => $result['content'],
+            ], JSON_UNESCAPED_UNICODE);
             break;
-            
+
         case 'voter_profile':
-            // Generate voter profile
-            $result = $chatGPT->generateVoterProfile($party['name'], $party);
-            
-            if (!$result['success']) {
-                echo json_encode([
-                    'success' => false, 
-                    'error' => 'Analysis API error: ' . $result['error']
-                ]);
-                exit;
+            $result = $chat_gpt->generateVoterProfile($party['name'], $party);
+            if (empty($result['success'])) {
+                party_analysis_error('Analysis failed', 502);
             }
-            
+
             echo json_encode([
                 'success' => true,
                 'type' => 'voter_profile',
                 'party_name' => $party['name'],
-                'content' => $result['content']
-            ]);
+                'content' => $result['content'],
+            ], JSON_UNESCAPED_UNICODE);
             break;
-            
+
         case 'timeline':
-            // Generate political timeline
-            $result = $chatGPT->generatePoliticalTimeline($party['name'], $party);
-            
-            if (!$result['success']) {
-                echo json_encode([
-                    'success' => false, 
-                    'error' => 'Analysis API error: ' . $result['error']
-                ]);
-                exit;
+            $result = $chat_gpt->generatePoliticalTimeline($party['name'], $party);
+            if (empty($result['success'])) {
+                party_analysis_error('Analysis failed', 502);
             }
-            
+
             echo json_encode([
                 'success' => true,
                 'type' => 'timeline',
                 'party_name' => $party['name'],
-                'content' => $result['content']
-            ]);
+                'content' => $result['content'],
+            ], JSON_UNESCAPED_UNICODE);
             break;
-            
+
         case 'question':
-            // Answer specific question
-            if (!isset($input['question']) || empty(trim($input['question']))) {
-                echo json_encode(['success' => false, 'error' => 'Question field is required for Q&A']);
-                exit;
+            $question = trim((string) ($input['question'] ?? ''));
+            if ($question === '') {
+                party_analysis_error('Question field is required for Q&A');
             }
-            
-            $question = trim($input['question']);
-            $result = $chatGPT->answerPartyQuestion($question, $party['name'], $party);
-            
-            if (!$result['success']) {
-                echo json_encode([
-                    'success' => false, 
-                    'error' => 'Analysis API error: ' . $result['error']
-                ]);
-                exit;
+
+            $result = $chat_gpt->answerPartyQuestion($question, $party['name'], $party);
+            if (empty($result['success'])) {
+                party_analysis_error('Analysis failed', 502);
             }
-            
+
             echo json_encode([
                 'success' => true,
                 'type' => 'question',
                 'party_name' => $party['name'],
                 'question' => $question,
-                'content' => $result['content']
-            ]);
+                'content' => $result['content'],
+            ], JSON_UNESCAPED_UNICODE);
             break;
-            
+
         default:
-            echo json_encode(['success' => false, 'error' => 'Invalid analysis type. Use: party, leader, voter_profile, timeline, or question']);
+            party_analysis_error('Invalid analysis type. Use: party, leader, voter_profile, timeline, or question');
     }
-    
-} catch (Exception $e) {
-    echo json_encode([
-        'success' => false, 
-        'error' => 'Server error: ' . $e->getMessage()
-    ]);
+} catch (Throwable $exception) {
+    party_analysis_error('Interne serverfout', 500, $exception);
 }
-?> 


### PR DESCRIPTION
Closes #46

## Wijzigingen
- ajax/party-analysis.php migreert naar centrale includes/error_bootstrap.php en verwijdert lokale display_errors instellingen.
- ajax/ai-polling-analysis.php migreert naar centrale includes/error_bootstrap.php en verwijdert lokale display_errors instellingen.
- Beide endpoints geven nu consistente, generieke JSON errors zonder stacktrace of bestandsdetails.
- Interne exception-details worden alleen server-side gelogd via error_log.

## Gewijzigde bestanden
- ajax/party-analysis.php - veilige foutafhandeling + generieke API responses
- ajax/ai-polling-analysis.php - veilige foutafhandeling + generieke API responses

## Test plan
- Handmatige POST naar beide endpoints met geldige payload geeft normale success-response.
- Ongeldige payload geeft gestandaardiseerde JSON error zonder trace.
- Interne fout geeft 'Interne serverfout' zonder path/line in response body.
- display_errors=1 niet meer aanwezig in beide entrypoints.

## Opmerking
- php -l kon in deze runner niet uitgevoerd worden omdat php binary ontbreekt op host.
