### PR TITLE
fix(controllers): migreer partijen-detail naar error bootstrap

### DIFF
--- a/controllers/partijen-detail.php
+++ b/controllers/partijen-detail.php
@@ -1,7 +1,5 @@
 <?php
-// Error reporting for development
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
+require_once dirname(__DIR__) . '/includes/error_bootstrap.php';
 
 // Base path
 if (!defined('BASE_PATH')) {


### PR DESCRIPTION
Closes #47

## Wijzigingen
- `controllers/partijen-detail.php` gebruikt nu centrale `includes/error_bootstrap.php`.
- Hardcoded `error_reporting(E_ALL)` en `display_errors=1` verwijderd uit publiek controller-entrypoint.
- Productiegedrag volgt nu uniforme APP_ENV/APP_DEBUG-regels van het project.

## Gewijzigde bestanden
- `controllers/partijen-detail.php` - lokale error-instellingen vervangen door bootstrap include.

## Test plan
- [x] Code-inspectie: geen hardcoded `display_errors=1` meer in controller.
- [ ] Syntax-check met `php -l controllers/partijen-detail.php` (kan niet in deze runtime: `php` ontbreekt).
- [ ] Handmatig verifiëren dat bestaande partijroutes onder `/partijen` en detailpagina's blijven werken.
