### PR TITLE
fix(controllers): harden uploads met MIME-checks en 0755 permissies

### DIFF
--- a/controllers/blogs.php
+++ b/controllers/blogs.php
@@ -48,95 +48,36 @@ class BlogsController {
 
             // Handle image upload
             if (isset($_FILES['image']) && $_FILES['image']['error'] === UPLOAD_ERR_OK) {
-                $upload_dir = BASE_PATH . '/uploads/blogs/images/';
-                $relative_upload_dir = 'uploads/blogs/images/';
-                
-                // Uitgebreide logging voor debugging
-                error_log("Blog image upload attempt - BASE_PATH: " . BASE_PATH);
-                error_log("Upload directory: " . $upload_dir);
-                error_log("Directory exists: " . (file_exists($upload_dir) ? 'YES' : 'NO'));
-                error_log("Directory writable: " . (is_writable($upload_dir) ? 'YES' : 'NO'));
-                
-                if (!file_exists($upload_dir)) {
-                    $mkdir_result = mkdir($upload_dir, 0755, true);
-                    error_log("Creating directory result: " . ($mkdir_result ? 'SUCCESS' : 'FAILED'));
-                    if ($mkdir_result) {
-                        chmod($upload_dir, 0755);
-                        error_log("Directory permissions set to 0755");
-                    }
-                }
-                
-                $file_extension = strtolower(pathinfo($_FILES['image']['name'], PATHINFO_EXTENSION));
-                $allowed_images = ['jpg', 'jpeg', 'png', 'gif'];
-                
-                error_log("File extension: " . $file_extension);
-                error_log("File size: " . $_FILES['image']['size']);
-                error_log("Temp file: " . $_FILES['image']['tmp_name']);
-                
-                if (in_array($file_extension, $allowed_images)) {
-                    $new_filename = uniqid() . '.' . $file_extension;
-                    $target_path = $upload_dir . $new_filename;
-                    
-                    error_log("Target path: " . $target_path);
-                    error_log("Temp file exists: " . (file_exists($_FILES['image']['tmp_name']) ? 'YES' : 'NO'));
-                    
-                    if (move_uploaded_file($_FILES['image']['tmp_name'], $target_path)) {
-                        // Store the relative path in database for compatibility
-                        $image_path = $relative_upload_dir . $new_filename;
-                        
-                        // Set correct file permissions
-                        chmod($target_path, 0644);
-                        
-                        // Debug: Log the upload success
-                        error_log("Blog image uploaded successfully: " . $image_path);
-                        error_log("File size after upload: " . filesize($target_path));
-                    } else {
-                        // Debug: Log upload failure with more details
-                        error_log("Blog image upload failed for file: " . $_FILES['image']['name']);
-                        error_log("Upload error details - Source: " . $_FILES['image']['tmp_name'] . ", Target: " . $target_path);
-                        error_log("Last error: " . error_get_last()['message']);
-                    }
+                $upload_result = store_uploaded_media(
+                    $_FILES['image'],
+                    BASE_PATH . '/uploads/blogs/images/',
+                    'uploads/blogs/images/',
+                    ['jpg', 'jpeg', 'png', 'gif', 'webp'],
+                    ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
+                );
+
+                if ($upload_result['ok']) {
+                    $image_path = $upload_result['path'];
                 } else {
-                    error_log("Invalid file extension: " . $file_extension . " for file: " . $_FILES['image']['name']);
+                    error_log('Blog image upload rejected: ' . $upload_result['error']);
                 }
-            } else if (isset($_FILES['image']) && $_FILES['image']['error'] !== UPLOAD_ERR_NO_FILE) {
-                // Log upload errors
-                $upload_errors = [
-                    UPLOAD_ERR_INI_SIZE => 'File exceeds upload_max_filesize',
-                    UPLOAD_ERR_FORM_SIZE => 'File exceeds MAX_FILE_SIZE',
-                    UPLOAD_ERR_PARTIAL => 'File was only partially uploaded',
-                    UPLOAD_ERR_NO_FILE => 'No file was uploaded',
-                    UPLOAD_ERR_NO_TMP_DIR => 'Missing temporary folder',
-                    UPLOAD_ERR_CANT_WRITE => 'Failed to write file to disk',
-                    UPLOAD_ERR_EXTENSION => 'File upload stopped by extension'
-                ];
-                $error_msg = isset($upload_errors[$_FILES['image']['error']]) ? $upload_errors[$_FILES['image']['error']] : 'Unknown upload error';
-                error_log("Blog image upload error: " . $error_msg . " (Code: " . $_FILES['image']['error'] . ")");
             }
 
             // Handle video upload
             if (isset($_FILES['video']) && $_FILES['video']['error'] === UPLOAD_ERR_OK) {
-                $upload_dir = BASE_PATH . '/uploads/blogs/videos/';
-                $relative_upload_dir = 'uploads/blogs/videos/';
-                
-                if (!file_exists($upload_dir)) {
-                    mkdir($upload_dir, 0777, true);
-                }
-                
-                $file_extension = strtolower(pathinfo($_FILES['video']['name'], PATHINFO_EXTENSION));
-                $allowed_videos = ['mp4', 'webm', 'ogg'];
-                
-                if (in_array($file_extension, $allowed_videos)) {
-                    // Check file size (max 100MB)
-                    if ($_FILES['video']['size'] <= 100 * 1024 * 1024) {
-                        $new_filename = uniqid() . '.' . $file_extension;
-                        $target_path = $upload_dir . $new_filename;
-                        
-                        if (move_uploaded_file($_FILES['video']['tmp_name'], $target_path)) {
-                            // Store the relative path in database for compatibility
-                            $video_path = $relative_upload_dir . $new_filename;
-                        }
-                    }
+                $upload_result = store_uploaded_media(
+                    $_FILES['video'],
+                    BASE_PATH . '/uploads/blogs/videos/',
+                    'uploads/blogs/videos/',
+                    ['mp4', 'webm', 'ogg'],
+                    ['video/mp4', 'video/webm', 'video/ogg', 'application/ogg'],
+                    100 * 1024 * 1024
+                );
+
+                if ($upload_result['ok']) {
+                    $video_path = $upload_result['path'];
+                } else {
+                    error_log('Blog video upload rejected: ' . $upload_result['error']);
                 }
             }
 
@@ -154,91 +95,23 @@ class BlogsController {
 
             // Handle audio upload voor podcast
             $audio_path = '';
-            
-            // Debug: Log audio upload attempt
-            error_log("=== AUDIO UPLOAD DEBUG START ===");
-            error_log("Audio file isset: " . (isset($_FILES['audio']) ? 'YES' : 'NO'));
-            if (isset($_FILES['audio'])) {
-                error_log("Audio file data: " . print_r($_FILES['audio'], true));
-            }
-            
-            // Handle lokaal audio bestand upload
+
             if (isset($_FILES['audio']) && $_FILES['audio']['error'] === UPLOAD_ERR_OK) {
-                $upload_dir = BASE_PATH . '/uploads/blogs/audio/';
-                $relative_upload_dir = 'uploads/blogs/audio/';
-                
-                // Uitgebreide logging voor debugging
-                error_log("Audio upload attempt - BASE_PATH: " . BASE_PATH);
-                error_log("Audio upload directory: " . $upload_dir);
-                error_log("Directory exists: " . (file_exists($upload_dir) ? 'YES' : 'NO'));
-                
-                if (!file_exists($upload_dir)) {
-                    $mkdir_result = mkdir($upload_dir, 0777, true);
-                    error_log("Creating audio directory result: " . ($mkdir_result ? 'SUCCESS' : 'FAILED'));
-                    if ($mkdir_result) {
-                        chmod($upload_dir, 0777);
-                        error_log("Audio directory permissions set to 0777");
-                    }
-                }
-                
-                error_log("Directory writable: " . (is_writable($upload_dir) ? 'YES' : 'NO'));
-                
-                $file_extension = strtolower(pathinfo($_FILES['audio']['name'], PATHINFO_EXTENSION));
-                $allowed_audio = ['mp3', 'wav', 'ogg'];
-                
-                error_log("Audio file extension: " . $file_extension);
-                error_log("Audio file size: " . $_FILES['audio']['size'] . " bytes");
-                error_log("Audio temp file: " . $_FILES['audio']['tmp_name']);
-                error_log("Audio temp file exists: " . (file_exists($_FILES['audio']['tmp_name']) ? 'YES' : 'NO'));
-                
-                if (in_array($file_extension, $allowed_audio)) {
-                    // Check bestandsgrootte (max 100MB)
-                    if ($_FILES['audio']['size'] <= 100 * 1024 * 1024) {
-                        $new_filename = uniqid() . '.' . $file_extension;
-                        $target_path = $upload_dir . $new_filename;
-                        
-                        error_log("Audio target path: " . $target_path);
-                        
-                        if (move_uploaded_file($_FILES['audio']['tmp_name'], $target_path)) {
-                            // Store the relative path in database for compatibility
-                            $audio_path = $relative_upload_dir . $new_filename;
-                            
-                            // Set correct file permissions
-                            chmod($target_path, 0644);
-                            
-                            error_log("Audio uploaded successfully: " . $audio_path);
-                            error_log("Audio file size after upload: " . filesize($target_path));
-                        } else {
-                            error_log("Audio upload FAILED for file: " . $_FILES['audio']['name']);
-                            error_log("Upload error details - Source: " . $_FILES['audio']['tmp_name'] . ", Target: " . $target_path);
-                            $last_error = error_get_last();
-                            if ($last_error) {
-                                error_log("Last error: " . $last_error['message']);
-                            }
-                        }
-                    } else {
-                        error_log("Audio file too large: " . $_FILES['audio']['size'] . " bytes (max 100MB)");
-                    }
+                $upload_result = store_uploaded_media(
+                    $_FILES['audio'],
+                    BASE_PATH . '/uploads/blogs/audio/',
+                    'uploads/blogs/audio/',
+                    ['mp3', 'wav', 'ogg'],
+                    ['audio/mpeg', 'audio/wav', 'audio/x-wav', 'audio/ogg', 'application/ogg'],
+                    100 * 1024 * 1024
+                );
+
+                if ($upload_result['ok']) {
+                    $audio_path = $upload_result['path'];
                 } else {
-                    error_log("Invalid audio file extension: " . $file_extension . " for file: " . $_FILES['audio']['name']);
+                    error_log('Blog audio upload rejected: ' . $upload_result['error']);
                 }
-            } else if (isset($_FILES['audio']) && $_FILES['audio']['error'] !== UPLOAD_ERR_NO_FILE) {
-                // Log upload errors
-                $upload_errors = [
-                    UPLOAD_ERR_INI_SIZE => 'The uploaded file exceeds the upload_max_filesize directive in php.ini',
-                    UPLOAD_ERR_FORM_SIZE => 'The uploaded file exceeds the MAX_FILE_SIZE directive in the HTML form',
-                    UPLOAD_ERR_PARTIAL => 'The uploaded file was only partially uploaded',
-                    UPLOAD_ERR_NO_TMP_DIR => 'Missing a temporary folder',
-                    UPLOAD_ERR_CANT_WRITE => 'Failed to write file to disk',
-                    UPLOAD_ERR_EXTENSION => 'A PHP extension stopped the file upload',
-                ];
-                $error_code = $_FILES['audio']['error'];
-                $error_message = isset($upload_errors[$error_code]) ? $upload_errors[$error_code] : 'Unknown upload error';
-                error_log("Audio upload error (code $error_code): $error_message");
-            } else {
-                error_log("No audio file uploaded or UPLOAD_ERR_NO_FILE");
             }
-            error_log("=== AUDIO UPLOAD DEBUG END ===");
             
             // Create blog post data
             $data = [
@@ -371,102 +244,42 @@ class BlogsController {
 
             // Handle new image upload if provided
             if (isset($_FILES['image']) && $_FILES['image']['error'] === UPLOAD_ERR_OK) {
-                $upload_dir = BASE_PATH . '/uploads/blogs/images/';
-                $relative_upload_dir = 'uploads/blogs/images/';
-                
-                // Uitgebreide logging voor debugging (edit functie)
-                error_log("Blog image edit upload attempt - BASE_PATH: " . BASE_PATH);
-                error_log("Upload directory: " . $upload_dir);
-                error_log("Directory exists: " . (file_exists($upload_dir) ? 'YES' : 'NO'));
-                error_log("Directory writable: " . (is_writable($upload_dir) ? 'YES' : 'NO'));
-                
-                if (!file_exists($upload_dir)) {
-                    $mkdir_result = mkdir($upload_dir, 0755, true);
-                    error_log("Creating directory result: " . ($mkdir_result ? 'SUCCESS' : 'FAILED'));
-                    if ($mkdir_result) {
-                        chmod($upload_dir, 0755);
-                        error_log("Directory permissions set to 0755");
+                $upload_result = store_uploaded_media(
+                    $_FILES['image'],
+                    BASE_PATH . '/uploads/blogs/images/',
+                    'uploads/blogs/images/',
+                    ['jpg', 'jpeg', 'png', 'gif', 'webp'],
+                    ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
+                );
+
+                if ($upload_result['ok']) {
+                    if (!empty($blog->image_path) && file_exists(BASE_PATH . '/' . $blog->image_path)) {
+                        unlink(BASE_PATH . '/' . $blog->image_path);
                     }
-                }
-                
-                $file_extension = strtolower(pathinfo($_FILES['image']['name'], PATHINFO_EXTENSION));
-                $allowed_images = ['jpg', 'jpeg', 'png', 'gif'];
-                
-                error_log("File extension: " . $file_extension);
-                error_log("File size: " . $_FILES['image']['size']);
-                error_log("Temp file: " . $_FILES['image']['tmp_name']);
-                
-                if (in_array($file_extension, $allowed_images)) {
-                    $new_filename = uniqid() . '.' . $file_extension;
-                    $target_path = $upload_dir . $new_filename;
-                    
-                    error_log("Target path: " . $target_path);
-                    error_log("Temp file exists: " . (file_exists($_FILES['image']['tmp_name']) ? 'YES' : 'NO'));
-                    
-                    if (move_uploaded_file($_FILES['image']['tmp_name'], $target_path)) {
-                        // Delete old image if it exists  
-                        if (!empty($blog->image_path) && file_exists(BASE_PATH . '/' . $blog->image_path)) {
-                            unlink(BASE_PATH . '/' . $blog->image_path);
-                            error_log("Old image deleted: " . $blog->image_path);
-                        }
-                        // Store the relative path in database for compatibility
-                        $image_path = $relative_upload_dir . $new_filename;
-                        
-                        // Set correct file permissions
-                        chmod($target_path, 0644);
-                        
-                        error_log("Blog image edit uploaded successfully: " . $image_path);
-                        error_log("File size after upload: " . filesize($target_path));
-                    } else {
-                        error_log("Blog image edit upload failed for file: " . $_FILES['image']['name']);
-                        error_log("Upload error details - Source: " . $_FILES['image']['tmp_name'] . ", Target: " . $target_path);
-                        error_log("Last error: " . error_get_last()['message']);
-                    }
+                    $image_path = $upload_result['path'];
                 } else {
-                    error_log("Invalid file extension: " . $file_extension . " for file: " . $_FILES['image']['name']);
+                    error_log('Blog image edit upload rejected: ' . $upload_result['error']);
                 }
-            } else if (isset($_FILES['image']) && $_FILES['image']['error'] !== UPLOAD_ERR_NO_FILE) {
-                // Log upload errors for edit
-                $upload_errors = [
-                    UPLOAD_ERR_INI_SIZE => 'File exceeds upload_max_filesize',
-                    UPLOAD_ERR_FORM_SIZE => 'File exceeds MAX_FILE_SIZE',
-                    UPLOAD_ERR_PARTIAL => 'File was only partially uploaded',
-                    UPLOAD_ERR_NO_FILE => 'No file was uploaded',
-                    UPLOAD_ERR_NO_TMP_DIR => 'Missing temporary folder',
-                    UPLOAD_ERR_CANT_WRITE => 'Failed to write file to disk',
-                    UPLOAD_ERR_EXTENSION => 'File upload stopped by extension'
-                ];
-                $error_msg = isset($upload_errors[$_FILES['image']['error']]) ? $upload_errors[$_FILES['image']['error']] : 'Unknown upload error';
-                error_log("Blog image edit upload error: " . $error_msg . " (Code: " . $_FILES['image']['error'] . ")");
             }
 
             // Handle new video upload if provided
             if (isset($_FILES['video']) && $_FILES['video']['error'] === UPLOAD_ERR_OK) {
-                $upload_dir = BASE_PATH . '/uploads/blogs/videos/';
-                $relative_upload_dir = 'uploads/blogs/videos/';
-                
-                if (!file_exists($upload_dir)) {
-                    mkdir($upload_dir, 0777, true);
-                }
-                
-                $file_extension = strtolower(pathinfo($_FILES['video']['name'], PATHINFO_EXTENSION));
-                $allowed_videos = ['mp4', 'webm', 'ogg'];
-                
-                if (in_array($file_extension, $allowed_videos)) {
-                    // Check file size (max 100MB)
-                    if ($_FILES['video']['size'] <= 100 * 1024 * 1024) {
-                        $new_filename = uniqid() . '.' . $file_extension;
-                        $target_path = $upload_dir . $new_filename;
-                        
-                        if (move_uploaded_file($_FILES['video']['tmp_name'], $target_path)) {
-                            // Delete old video if it exists
-                            if (!empty($blog->video_path) && file_exists(BASE_PATH . '/' . $blog->video_path)) {
-                                unlink(BASE_PATH . '/' . $blog->video_path);
-                            }
-                            // Store the relative path in database for compatibility
-                            $video_path = $relative_upload_dir . $new_filename;
-                        }
+                $upload_result = store_uploaded_media(
+                    $_FILES['video'],
+                    BASE_PATH . '/uploads/blogs/videos/',
+                    'uploads/blogs/videos/',
+                    ['mp4', 'webm', 'ogg'],
+                    ['video/mp4', 'video/webm', 'video/ogg', 'application/ogg'],
+                    100 * 1024 * 1024
+                );
+
+                if ($upload_result['ok']) {
+                    if (!empty($blog->video_path) && file_exists(BASE_PATH . '/' . $blog->video_path)) {
+                        unlink(BASE_PATH . '/' . $blog->video_path);
                     }
+                    $video_path = $upload_result['path'];
+                } else {
+                    error_log('Blog video edit upload rejected: ' . $upload_result['error']);
                 }
             }
 
@@ -486,107 +299,34 @@ class BlogsController {
 
             // Handle audio updates
             $audio_path = isset($blog->audio_path) ? $blog->audio_path : ''; // Keep existing audio by default
-            
-            // Debug: Log audio upload attempt for edit
-            error_log("=== AUDIO UPLOAD DEBUG (EDIT) START ===");
-            error_log("Audio file isset: " . (isset($_FILES['audio']) ? 'YES' : 'NO'));
-            error_log("Existing audio_path: " . $audio_path);
-            if (isset($_FILES['audio'])) {
-                error_log("Audio file data: " . print_r($_FILES['audio'], true));
-            }
-            
+
             // Handle remove_audio checkbox
             if (isset($_POST['remove_audio']) && $_POST['remove_audio'] === 'on') {
-                // Delete existing audio file
                 if (!empty($blog->audio_path) && file_exists(BASE_PATH . '/' . $blog->audio_path)) {
                     unlink(BASE_PATH . '/' . $blog->audio_path);
-                    error_log("Deleted existing audio file: " . $blog->audio_path);
                 }
                 $audio_path = '';
             }
-            
-            // Handle lokaal audio bestand upload
+
             if (isset($_FILES['audio']) && $_FILES['audio']['error'] === UPLOAD_ERR_OK) {
-                $upload_dir = BASE_PATH . '/uploads/blogs/audio/';
-                $relative_upload_dir = 'uploads/blogs/audio/';
-                
-                // Uitgebreide logging voor debugging
-                error_log("Audio upload attempt (edit) - BASE_PATH: " . BASE_PATH);
-                error_log("Audio upload directory: " . $upload_dir);
-                error_log("Directory exists: " . (file_exists($upload_dir) ? 'YES' : 'NO'));
-                
-                if (!file_exists($upload_dir)) {
-                    $mkdir_result = mkdir($upload_dir, 0777, true);
-                    error_log("Creating audio directory result: " . ($mkdir_result ? 'SUCCESS' : 'FAILED'));
-                    if ($mkdir_result) {
-                        chmod($upload_dir, 0777);
-                        error_log("Audio directory permissions set to 0777");
+                $upload_result = store_uploaded_media(
+                    $_FILES['audio'],
+                    BASE_PATH . '/uploads/blogs/audio/',
+                    'uploads/blogs/audio/',
+                    ['mp3', 'wav', 'ogg'],
+                    ['audio/mpeg', 'audio/wav', 'audio/x-wav', 'audio/ogg', 'application/ogg'],
+                    100 * 1024 * 1024
+                );
+
+                if ($upload_result['ok']) {
+                    if (!empty($blog->audio_path) && file_exists(BASE_PATH . '/' . $blog->audio_path)) {
+                        unlink(BASE_PATH . '/' . $blog->audio_path);
                     }
-                }
-                
-                error_log("Directory writable: " . (is_writable($upload_dir) ? 'YES' : 'NO'));
-                
-                $file_extension = strtolower(pathinfo($_FILES['audio']['name'], PATHINFO_EXTENSION));
-                $allowed_audio = ['mp3', 'wav', 'ogg'];
-                
-                error_log("Audio file extension: " . $file_extension);
-                error_log("Audio file size: " . $_FILES['audio']['size'] . " bytes");
-                error_log("Audio temp file: " . $_FILES['audio']['tmp_name']);
-                error_log("Audio temp file exists: " . (file_exists($_FILES['audio']['tmp_name']) ? 'YES' : 'NO'));
-                
-                if (in_array($file_extension, $allowed_audio)) {
-                    // Check bestandsgrootte (max 100MB)
-                    if ($_FILES['audio']['size'] <= 100 * 1024 * 1024) {
-                        $new_filename = uniqid() . '.' . $file_extension;
-                        $target_path = $upload_dir . $new_filename;
-                        
-                        error_log("Audio target path: " . $target_path);
-                        
-                        if (move_uploaded_file($_FILES['audio']['tmp_name'], $target_path)) {
-                            // Delete old audio if it exists
-                            if (!empty($blog->audio_path) && file_exists(BASE_PATH . '/' . $blog->audio_path)) {
-                                unlink(BASE_PATH . '/' . $blog->audio_path);
-                                error_log("Deleted old audio file: " . $blog->audio_path);
-                            }
-                            // Store the relative path in database for compatibility
-                            $audio_path = $relative_upload_dir . $new_filename;
-                            
-                            // Set correct file permissions
-                            chmod($target_path, 0644);
-                            
-                            error_log("Audio uploaded successfully: " . $audio_path);
-                            error_log("Audio file size after upload: " . filesize($target_path));
-                        } else {
-                            error_log("Audio upload FAILED for file: " . $_FILES['audio']['name']);
-                            error_log("Upload error details - Source: " . $_FILES['audio']['tmp_name'] . ", Target: " . $target_path);
-                            $last_error = error_get_last();
-                            if ($last_error) {
-                                error_log("Last error: " . $last_error['message']);
-                            }
-                        }
-                    } else {
-                        error_log("Audio file too large: " . $_FILES['audio']['size'] . " bytes (max 100MB)");
-                    }
+                    $audio_path = $upload_result['path'];
                 } else {
-                    error_log("Invalid audio file extension: " . $file_extension . " for file: " . $_FILES['audio']['name']);
+                    error_log('Blog audio edit upload rejected: ' . $upload_result['error']);
                 }
-            } else if (isset($_FILES['audio']) && $_FILES['audio']['error'] !== UPLOAD_ERR_NO_FILE) {
-                // Log upload errors
-                $upload_errors = [
-                    UPLOAD_ERR_INI_SIZE => 'The uploaded file exceeds the upload_max_filesize directive in php.ini',
-                    UPLOAD_ERR_FORM_SIZE => 'The uploaded file exceeds the MAX_FILE_SIZE directive in the HTML form',
-                    UPLOAD_ERR_PARTIAL => 'The uploaded file was only partially uploaded',
-                    UPLOAD_ERR_NO_TMP_DIR => 'Missing a temporary folder',
-                    UPLOAD_ERR_CANT_WRITE => 'Failed to write file to disk',
-                    UPLOAD_ERR_EXTENSION => 'A PHP extension stopped the file upload',
-                ];
-                $error_code = $_FILES['audio']['error'];
-                $error_message = isset($upload_errors[$error_code]) ? $upload_errors[$error_code] : 'Unknown upload error';
-                error_log("Audio upload error (code $error_code): $error_message");
-            } else {
-                error_log("No audio file uploaded or UPLOAD_ERR_NO_FILE");
             }
-            error_log("=== AUDIO UPLOAD DEBUG (EDIT) END ===");
             
             // Handle category update
             $category_id = filter_input(INPUT_POST, 'category_id', FILTER_VALIDATE_INT);

--- a/controllers/profile/edit.php
+++ b/controllers/profile/edit.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/../../includes/config.php';
 require_once __DIR__ . '/../../includes/auth_check.php';
 require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../../includes/helpers.php';
 
 $user_id = $_SESSION['user_id'];
 $error = '';
@@ -24,42 +25,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $photo_updated = false;
     
     if (isset($_FILES['profile_photo']) && $_FILES['profile_photo']['error'] === UPLOAD_ERR_OK) {
-        $allowed_types = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-        $file_type = $_FILES['profile_photo']['type'];
-        $file_size = $_FILES['profile_photo']['size'];
-        $max_size = 5 * 1024 * 1024; // 5MB max size
-        
-        if (!in_array($file_type, $allowed_types)) {
-            $error = "Alleen JPG, PNG, GIF of WEBP afbeeldingen zijn toegestaan.";
-        } elseif ($file_size > $max_size) {
-            $error = "De afbeelding mag niet groter zijn dan 5MB.";
+        $result = store_uploaded_media(
+            $_FILES['profile_photo'],
+            BASE_PATH . '/public/uploads/profile_photos/',
+            'uploads/profile_photos/',
+            ['jpg', 'jpeg', 'png', 'gif', 'webp'],
+            ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+            5 * 1024 * 1024
+        );
+
+        if (!$result['ok']) {
+            $error = $result['error'] === 'file_too_large'
+                ? "De afbeelding mag niet groter zijn dan 5MB."
+                : "Alleen geldige JPG, PNG, GIF of WEBP afbeeldingen zijn toegestaan.";
         } else {
-            // Create upload directory if it doesn't exist
-            $upload_dir = BASE_PATH . '/public/uploads/profile_photos/';
-            if (!file_exists($upload_dir)) {
-                mkdir($upload_dir, 0755, true);
-            }
-            
-            // Generate unique filename
-            $file_extension = pathinfo($_FILES['profile_photo']['name'], PATHINFO_EXTENSION);
-            $filename = 'profile_' . $user_id . '_' . uniqid() . '.' . $file_extension;
-            $destination = $upload_dir . $filename;
-            
-            // Move uploaded file
-            if (move_uploaded_file($_FILES['profile_photo']['tmp_name'], $destination)) {
-                $profile_photo = 'uploads/profile_photos/' . $filename;
-                $photo_updated = true;
-                
-                // Delete old photo if exists
-                $stmt = $pdo->prepare("SELECT profile_photo FROM users WHERE id = ?");
-                $stmt->execute([$user_id]);
-                $old_photo = $stmt->fetchColumn();
-                
-                if ($old_photo && file_exists(BASE_PATH . '/public/' . $old_photo)) {
-                    unlink(BASE_PATH . '/public/' . $old_photo);
-                }
-            } else {
-                $error = "Er is een fout opgetreden bij het uploaden van de afbeelding.";
+            $profile_photo = $result['path'];
+            $photo_updated = true;
+
+            // Delete old photo if exists
+            $stmt = $pdo->prepare("SELECT profile_photo FROM users WHERE id = ?");
+            $stmt->execute([$user_id]);
+            $old_photo = $stmt->fetchColumn();
+
+            if ($old_photo && file_exists(BASE_PATH . '/public/' . $old_photo)) {
+                unlink(BASE_PATH . '/public/' . $old_photo);
             }
         }
     } elseif (isset($_POST['remove_photo']) && $_POST['remove_photo'] === '1') {

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -58,6 +58,86 @@ if (!function_exists('isAdmin')) {
     }
 }
 
+if (!function_exists('ensure_upload_directory')) {
+    /**
+     * Zorgt dat de upload map bestaat met veilige permissies.
+     */
+    function ensure_upload_directory($upload_dir) {
+        if (!is_dir($upload_dir)) {
+            if (!mkdir($upload_dir, 0755, true)) {
+                return false;
+            }
+        }
+
+        return chmod($upload_dir, 0755) || is_writable($upload_dir);
+    }
+}
+
+if (!function_exists('get_uploaded_mime_type')) {
+    /**
+     * Bepaalt MIME-type server-side met finfo.
+     */
+    function get_uploaded_mime_type($tmp_name) {
+        if (!is_uploaded_file($tmp_name) || !function_exists('finfo_open')) {
+            return null;
+        }
+
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+        if (!$finfo) {
+            return null;
+        }
+
+        $mime = finfo_file($finfo, $tmp_name) ?: null;
+        finfo_close($finfo);
+
+        return $mime;
+    }
+}
+
+if (!function_exists('store_uploaded_media')) {
+    /**
+     * Valideert en slaat media upload veilig op.
+     */
+    function store_uploaded_media($file, $upload_dir, $relative_upload_dir, $allowed_extensions, $allowed_mimes, $max_size_bytes = null) {
+        if (!isset($file['error']) || $file['error'] !== UPLOAD_ERR_OK) {
+            return ['ok' => false, 'error' => 'upload_error'];
+        }
+
+        if (!ensure_upload_directory($upload_dir)) {
+            return ['ok' => false, 'error' => 'directory_error'];
+        }
+
+        $extension = strtolower(pathinfo($file['name'] ?? '', PATHINFO_EXTENSION));
+        if (!in_array($extension, $allowed_extensions, true)) {
+            return ['ok' => false, 'error' => 'invalid_extension'];
+        }
+
+        $mime = get_uploaded_mime_type($file['tmp_name'] ?? '');
+        if ($mime === null || !in_array($mime, $allowed_mimes, true)) {
+            return ['ok' => false, 'error' => 'invalid_mime'];
+        }
+
+        if ($max_size_bytes !== null && isset($file['size']) && (int)$file['size'] > $max_size_bytes) {
+            return ['ok' => false, 'error' => 'file_too_large'];
+        }
+
+        $filename = uniqid('', true) . '.' . $extension;
+        $target_path = rtrim($upload_dir, '/') . '/' . $filename;
+
+        if (!move_uploaded_file($file['tmp_name'], $target_path)) {
+            return ['ok' => false, 'error' => 'move_failed'];
+        }
+
+        chmod($target_path, 0644);
+
+        return [
+            'ok' => true,
+            'path' => rtrim($relative_upload_dir, '/') . '/' . $filename,
+            'mime' => $mime,
+        ];
+    }
+}
+
 if (!function_exists('getBlogImageUrl')) {
     /**
      * Gets the correct URL for a blog image


### PR DESCRIPTION
Closes #52

## Wijzigingen
- Upload-validatie gecentraliseerd in `store_uploaded_media()` (helpers) met server-side MIME-check via `finfo_file` + extensiecontrole.
- Alle uploadmappen worden nu met veilige permissies (`0755`) aangemaakt via `ensure_upload_directory()`.
- Uploadflows in `controllers/blogs.php` (create/edit voor image, video, audio) en `controllers/profile/edit.php` hergebruiken dezelfde hardening.
- Overmatige debug logging met absolute paden/tmp-bestanden verwijderd en vervangen door generieke reject-logging.

## Gewijzigde bestanden
- `includes/helpers.php`
- `controllers/blogs.php`
- `controllers/profile/edit.php`

## Test plan
- [x] Statische codecheck op 0777- en debug-paths in aangepaste bestanden
- [ ] `php -l controllers/blogs.php`
- [ ] `php -l controllers/profile/edit.php`
- [ ] `php -l includes/helpers.php`

> Op deze runner is `php` niet geïnstalleerd, dus `php -l` kon hier niet uitgevoerd worden.
