### PR TITLE
perf(blogs): verplaats sitemap-regeneratie naar async queue

### DIFF
--- a/controllers/blogs.php
+++ b/controllers/blogs.php
@@ -145,8 +145,8 @@ class BlogsController {
                 $newsletterController = new Newsletter();
                 $newsletterController->sendNewBlogNotifications($blogId);
                 
-                // Automatically regenerate sitemap
-                $this->regenerateSitemap();
+                // Trigger asynchrone sitemap-regeneratie (non-blocking)
+                $this->queueSitemapRegeneration();
                 
                 // Redirect to blogs page
                 header('Location: ' . URLROOT . '/blogs');
@@ -368,8 +368,8 @@ class BlogsController {
             ];
             
             if ($this->blogModel->update($data)) {
-                // Automatically regenerate sitemap after blog update
-                $this->regenerateSitemap();
+                // Trigger asynchrone sitemap-regeneratie na update (non-blocking)
+                $this->queueSitemapRegeneration();
                 
                 header('Location: ' . URLROOT . '/blogs/manage');
                 exit;
@@ -419,8 +419,8 @@ class BlogsController {
                 unlink(BASE_PATH . '/' . $blog->audio_path);
             }
             
-            // Automatically regenerate sitemap after blog deletion
-            $this->regenerateSitemap();
+            // Trigger asynchrone sitemap-regeneratie na verwijderen (non-blocking)
+            $this->queueSitemapRegeneration();
         }
         
         header('Location: ' . URLROOT . '/blogs/manage');
@@ -497,42 +497,29 @@ class BlogsController {
         }
     }
     
-    private function regenerateSitemap() {
+    private function queueSitemapRegeneration() {
+        $queueDir = BASE_PATH . '/storage/queues';
+        $queueFile = $queueDir . '/sitemap-regenerate.json';
+
         try {
-            // Voer het sitemap generatie script uit
-            $output = shell_exec('cd ' . BASE_PATH . ' && php generate-sitemap.php > sitemap.xml 2>&1');
-            
-            // Log voor debugging
-            error_log("Sitemap automatically regenerated after new blog post");
-            
-            // Optioneel: ping Google om de nieuwe sitemap te melden
-            $this->pingGoogleSitemap();
-            
-        } catch (Exception $e) {
-            // Log de fout maar laat de blog posting niet falen
-            error_log("Failed to regenerate sitemap: " . $e->getMessage());
+            if (!is_dir($queueDir) && !mkdir($queueDir, 0755, true) && !is_dir($queueDir)) {
+                throw new RuntimeException('Kon sitemap queue map niet aanmaken');
+            }
+
+            $payload = [
+                'queued_at' => date('c'),
+                'source' => 'blogs_controller',
+            ];
+
+            file_put_contents($queueFile, json_encode($payload, JSON_UNESCAPED_SLASHES));
+            error_log('Sitemap regeneratie in queue gezet');
+
+            // Fire-and-forget worker; faalt dit, dan kan cron scripts/process_sitemap_queue.php oppakken.
+            $worker = escapeshellarg(BASE_PATH . '/scripts/process_sitemap_queue.php');
+            @shell_exec('php ' . $worker . ' > /dev/null 2>&1 &');
+        } catch (Throwable $e) {
+            // Nooit blog-publicatie blokkeren
+            error_log('Kon sitemap regeneratie niet in queue zetten: ' . $e->getMessage());
         }
     }
-    
-    private function pingGoogleSitemap() {
-        try {
-            // Ping Google Search Console om nieuwe sitemap te melden
-            $sitemapUrl = urlencode('https://politiekpraat.nl/sitemap.xml');
-            $pingUrl = "https://www.google.com/ping?sitemap=" . $sitemapUrl;
-            
-            // Maak een non-blocking HTTP request
-            $context = stream_context_create([
-                'http' => [
-                    'timeout' => 5, // 5 seconden timeout
-                    'ignore_errors' => true
-                ]
-            ]);
-            
-            $result = file_get_contents($pingUrl, false, $context);
-            error_log("Google sitemap ping sent successfully");
-            
-        } catch (Exception $e) {
-            error_log("Failed to ping Google sitemap: " . $e->getMessage());
-        }
-    }
-} 
+}

--- a/scripts/process_sitemap_queue.php
+++ b/scripts/process_sitemap_queue.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+$basePath = dirname(__DIR__);
+$queueFile = $basePath . '/storage/queues/sitemap-regenerate.json';
+$lockFile = $basePath . '/storage/queues/sitemap-regenerate.lock';
+$logDir = $basePath . '/logs';
+$logFile = $logDir . '/sitemap-worker.log';
+
+if (!is_dir($logDir)) {
+    @mkdir($logDir, 0755, true);
+}
+
+$log = static function (string $message) use ($logFile): void {
+    $line = sprintf("[%s] %s\n", date('c'), $message);
+    @file_put_contents($logFile, $line, FILE_APPEND);
+    error_log('sitemap-worker: ' . $message);
+};
+
+if (!file_exists($queueFile)) {
+    $log('Geen sitemap-taak in queue, stop.');
+    exit(0);
+}
+
+$lockFp = @fopen($lockFile, 'c+');
+if ($lockFp === false) {
+    $log('Kon lockfile niet openen.');
+    exit(1);
+}
+
+if (!flock($lockFp, LOCK_EX | LOCK_NB)) {
+    $log('Worker draait al; deze run stopt.');
+    fclose($lockFp);
+    exit(0);
+}
+
+try {
+    $payloadRaw = @file_get_contents($queueFile);
+    $payload = $payloadRaw ? json_decode($payloadRaw, true) : [];
+    $queuedAt = $payload['queued_at'] ?? 'unknown';
+
+    $log('Start sitemap-regeneratie. queued_at=' . $queuedAt);
+
+    $cmd = 'cd ' . escapeshellarg($basePath) . ' && php generate-sitemap.php > sitemap.xml 2>&1';
+    $output = [];
+    $exitCode = 0;
+    exec($cmd, $output, $exitCode);
+
+    if ($exitCode !== 0) {
+        $log('Sitemap generatie faalde met exitcode ' . $exitCode . '. Queue blijft staan voor retry.');
+        exit(1);
+    }
+
+    $sitemapUrl = urlencode('https://politiekpraat.nl/sitemap.xml');
+    $pingUrl = 'https://www.google.com/ping?sitemap=' . $sitemapUrl;
+
+    $context = stream_context_create([
+        'http' => [
+            'timeout' => 5,
+            'ignore_errors' => true,
+        ],
+    ]);
+
+    @file_get_contents($pingUrl, false, $context);
+
+    @unlink($queueFile);
+    $log('Sitemap-regeneratie klaar en queue-item verwijderd.');
+    exit(0);
+} catch (Throwable $e) {
+    $log('Onverwachte fout: ' . $e->getMessage());
+    exit(1);
+} finally {
+    flock($lockFp, LOCK_UN);
+    fclose($lockFp);
+}


### PR DESCRIPTION
Closes #53

## Wijzigingen
- Blocking `shell_exec` uit blog create/update/delete flow gehaald.
- Nieuwe queue-trigger toegevoegd in `BlogsController` via `queueSitemapRegeneration()`.
- Nieuwe async worker toegevoegd: `scripts/process_sitemap_queue.php`.
- Worker verwerkt queue-item met lockfile, logging en non-blocking Google sitemap ping.
- Bij worker-falen blijft queue-item staan voor retry; blog-publicatie blijft altijd doorgaan.

## Gewijzigde bestanden
- `controllers/blogs.php` - vervangt directe sitemap-regeneratie door lichte queue-trigger.
- `scripts/process_sitemap_queue.php` - nieuwe asynchrone queue worker voor sitemap-regeneratie.

## Test plan
- [x] Handmatige code-inspectie: create/update/delete routes roepen geen blocking sitemap shell_exec meer aan.
- [x] Queue-pad + foutafhandeling gecontroleerd (publish flow blijft non-blocking).
- [ ] Runtime smoke test op host met PHP beschikbaar: create/update/delete blog en verifieer `logs/sitemap-worker.log`.
- [ ] (Optioneel) Cron laten wijzen naar `php scripts/process_sitemap_queue.php` als fallback worker.

## Opmerking
Op deze runner is geen `php` binary beschikbaar, daarom kon `php -l`/runtime test hier niet uitgevoerd worden.
