### PR TITLE
fix(home): live nieuwsfeed + werkende links op homepage

### DIFF
--- a/controllers/home.php
+++ b/controllers/home.php
@@ -5,6 +5,7 @@ require_once 'includes/OpenDataAPI.php';
 require_once 'includes/PoliticalDataAPI.php';
 require_once 'includes/PollAPI.php';
 require_once 'includes/BlogController.php';
+require_once 'models/NewsModel.php';
 
 // Helper functie om Markdown syntax te strippen
 function stripMarkdown($text) {
@@ -45,6 +46,7 @@ $openDataAPI = new OpenDataAPI();
 $politicalDataAPI = new PoliticalDataAPI();
 $pollAPI = new PollAPI();
 $blogController = new BlogController();
+$newsModel = new NewsModel($db);
 
 // Haal actuele politieke data op
 $kamerStats = $politicalDataAPI->getKamerStatistieken();
@@ -299,76 +301,54 @@ foreach ($featured_blogs as $blog) {
     $blog->summary = stripMarkdown($blog->summary);
 }
 
-// Haal het laatste nieuws op
-$news_sources = [
-    'links' => [
-        ['name' => 'De Volkskrant', 'bias' => 'links', 'url' => 'https://www.volkskrant.nl/voorpagina/rss.xml'],
-        ['name' => 'Trouw', 'bias' => 'centrum-links', 'url' => 'https://www.trouw.nl/rss.xml'],
-        ['name' => 'NRC', 'bias' => 'centrum-links', 'url' => 'https://www.nrc.nl/rss/']
-    ],
-    'rechts' => [
-        ['name' => 'Telegraaf', 'bias' => 'rechts', 'url' => 'https://www.telegraaf.nl/rss'],
-        ['name' => 'Reformatorisch Dagblad', 'bias' => 'rechts', 'url' => 'https://rd.nl/rss'],
-        ['name' => 'AD', 'bias' => 'centrum-rechts', 'url' => 'https://www.ad.nl/rss.xml']
-    ]
-];
+// Haal het laatste nieuws op uit database (primair) met robuuste fallback
+$latest_news = [];
 
-$latest_news = [
-    [
-        'orientation' => 'links',
-        'source' => 'De Volkskrant',
-        'bias' => 'centrum-links', 
-        'publishedAt' => date('Y-m-d H:i:s'), // Vandaag 08:30
-        'title' => 'Relschoppers in Den Haag beschadigden ook Binnenhof tijdens tocht door de stad',
-        'description' => 'Tijdens de rellen in Den Haag hebben relschoppers ook schade aangericht aan het Binnenhof. De ongeregeldheden verspreidden zich door de hele stad en het politieke hart van Nederland werd niet gespaard tijdens de gewelddadige tocht.',
-        'url' => 'https://www.volkskrant.nl/binnenland/relschoppers-in-den-haag-beschadigden-ook-binnenhof-tijdens-tocht-door-de-stad~b6bbfd7d/'
-    ],
-    [
-        'orientation' => 'links',
-        'source' => 'NRC',
-        'bias' => 'centrum-links', 
-        'publishedAt' => date('Y-m-d H:i:s', strtotime('-2 hours')), // 2 uur geleden
-        'title' => 'Burgers hebben genoeg van al die meningen, zodat Den Haag maar afziet van al te verhit debat',
-        'description' => 'Nederlandse burgers tonen steeds minder belangstelling voor verhitte politieke debatten. Politici in Den Haag worstelen met de vraag hoe zij nog kunnen doordringen tot een publiek dat moe is geworden van polarisatie en eindeloze meningsvorming.',
-        'url' => 'https://www.nrc.nl/nieuws/2025/09/19/burgers-hebben-genoeg-van-al-die-meningen-zodat-den-haag-maar-afziet-van-al-te-verhit-debat-a4906809'
-    ],
-    [
-        'orientation' => 'links',
-        'source' => 'Trouw',
-        'bias' => 'centrum-links', 
-        'publishedAt' => date('Y-m-d H:i:s', strtotime('-4 hours')), // 4 uur geleden
-        'title' => 'De Kamer noemt antifa een terroristische organisatie, maar antifa is niet terroristisch en ook geen organisatie',
-        'description' => 'De Tweede Kamer heeft een motie aangenomen waarin antifa wordt bestempeld als terroristische organisatie. Experts wijzen erop dat antifa echter geen georganiseerde structuur heeft en niet voldoet aan de definitie van terrorisme.',
-        'url' => 'https://www.trouw.nl/politiek/de-kamer-noemt-antifa-een-terroristische-organisatie-maar-antifa-is-niet-terroristisch-en-ook-geen-organisatie~b8651a25/'
-    ],
-    [
-        'orientation' => 'rechts',
-        'source' => 'Dagelijkse Standaard',
-        'bias' => 'rechts',
-        'publishedAt' => date('Y-m-d H:i:s', strtotime('-6 hours')), // 6 uur geleden
-        'title' => 'Timmermans misleidt: rellen Den Haag door hooligans, niet door extreemrechts',
-        'description' => 'Frans Timmermans wijt de rellen in Den Haag ten onrechte aan extreemrechts, terwijl het hooligans betrof. Een analyse van de werkelijke oorzaken achter de ongeregeldheden en de politieke framing die daarop volgde.',
-        'url' => 'https://www.dagelijksestandaard.nl/politiek/timmermans-misleidt-rellen-den-haag-door-hooligans-niet-door-extreemrechts'
-    ],
-    [
-        'orientation' => 'rechts',
-        'source' => 'De Telegraaf',
-        'bias' => 'rechts', 
-        'publishedAt' => date('Y-m-d H:i:s', strtotime('-8 hours')), // 8 uur geleden
-        'title' => 'Rob Jetten over aanval op D66-kantoor: \'Deze mensen hebben zich laten ophitsen\'',
-        'description' => 'D66-leider Rob Jetten reageert op de aanval op het partijkantoor. Hij stelt dat de daders zich hebben laten ophitsen door politieke retoriek en roept op tot meer respect in het politieke debat.',
-        'url' => 'https://www.telegraaf.nl/politiek/rob-jetten-over-aanval-op-d66-kantoor-deze-mensen-hebben-zich-laten-ophitsen/91850069.html'
-    ],
-    [
-        'orientation' => 'rechts',
-        'source' => 'Nieuw Rechts',
-        'bias' => 'rechts', 
-        'publishedAt' => date('Y-m-d H:i:s', strtotime('-10 hours')), // 10 uur geleden
-        'title' => 'Rapport onthult: EU gebruikt 250 miljoen voor academische propaganda',
-        'description' => 'Een nieuw rapport toont aan dat de Europese Unie jaarlijks 250 miljoen euro besteedt aan wat critici academische propaganda noemen. Het geld wordt gebruikt om universiteiten en onderzoeksinstellingen te financieren die de EU-agenda ondersteunen.',
-        'url' => 'https://nieuwrechts.nl/106542-rapport-onthult-eu-gebruikt-250-miljoen-voor-academische-propaganda'
-    ]
-];
+try {
+    $homepageNews = $newsModel->getHomepageNews(3, 48);
+    $latest_news = array_merge($homepageNews['links'], $homepageNews['rechts']);
+
+    // Filter op geldige externe links
+    $latest_news = array_values(array_filter($latest_news, function($article) {
+        if (empty($article['url']) || !filter_var($article['url'], FILTER_VALIDATE_URL)) {
+            return false;
+        }
+
+        $scheme = parse_url($article['url'], PHP_URL_SCHEME);
+        return in_array(strtolower((string)$scheme), ['http', 'https'], true);
+    }));
+
+    if (count($homepageNews['links']) < 3 || count($homepageNews['rechts']) < 3) {
+        error_log("home.php: fallback geactiveerd, onvoldoende recente items per perspectief (links=" . count($homepageNews['links']) . ", rechts=" . count($homepageNews['rechts']) . ")");
+    }
+} catch (Exception $e) {
+    error_log("home.php: ophalen homepage nieuws mislukt: " . $e->getMessage());
+}
+
+// Noodfallback zodat homepage nooit leeg is
+if (empty($latest_news)) {
+    error_log("home.php: noodfallback actief voor Laatste Politiek Nieuws");
+    $latest_news = [
+        [
+            'orientation' => 'links',
+            'source' => 'PolitiekPraat',
+            'bias' => 'Centrum-links',
+            'publishedAt' => date('Y-m-d H:i:s'),
+            'title' => 'Progressief nieuws wordt momenteel opnieuw geladen',
+            'description' => 'De live nieuwsfeed is tijdelijk niet beschikbaar. Probeer het over enkele minuten opnieuw.',
+            'url' => URLROOT . '/nieuws?filter=progressief'
+        ],
+        [
+            'orientation' => 'rechts',
+            'source' => 'PolitiekPraat',
+            'bias' => 'Centrum-rechts',
+            'publishedAt' => date('Y-m-d H:i:s'),
+            'title' => 'Conservatief nieuws wordt momenteel opnieuw geladen',
+            'description' => 'De live nieuwsfeed is tijdelijk niet beschikbaar. Probeer het over enkele minuten opnieuw.',
+            'url' => URLROOT . '/nieuws?filter=conservatief'
+        ]
+    ];
+}
 
 // Haal actuele data op
 $actuele_themas = $openDataAPI->getActueleThemas();

--- a/includes/NewsScraper.php
+++ b/includes/NewsScraper.php
@@ -9,12 +9,12 @@ class NewsScraper {
     // Configuratie voor nieuwsbronnen met hun RSS feeds en oriëntatie
     private $newsSources = [
         'De Volkskrant' => [
-            'rss_url' => 'https://www.volkskrant.nl/columns-van-de-dag/rss.xml',
+            'rss_url' => 'https://www.volkskrant.nl/nieuws-achtergrond/politiek/rss.xml',
             'orientation' => 'links',
             'bias' => 'Progressief'
         ],
         'NRC' => [
-            'rss_url' => 'https://www.nrc.nl/rss/',
+            'rss_url' => 'https://www.nrc.nl/sectie/politiek/rss/',
             'orientation' => 'links',
             'bias' => 'Liberaal'
         ],
@@ -24,14 +24,14 @@ class NewsScraper {
             'bias' => 'Progressief'
         ],
         'Telegraaf' => [
-            'rss_url' => 'https://www.telegraaf.nl/rss/',
+            'rss_url' => 'https://www.telegraaf.nl/nieuws/politiek/rss',
             'orientation' => 'rechts',
             'bias' => 'Conservatief'
         ],
         'AD' => [
             'rss_url' => 'https://www.ad.nl/politiek/rss.xml',
-            'orientation' => 'midden',
-            'bias' => 'conservatief'
+            'orientation' => 'rechts',
+            'bias' => 'Centrum-rechts'
         ],
         'NU.nl' => [
             'rss_url' => 'https://www.nu.nl/rss/Politiek',
@@ -92,6 +92,8 @@ class NewsScraper {
                         
                         if ($success) {
                             $scrapedCount++;
+                        } else if ($isCLI) {
+                            echo "  Artikel overgeslagen (invalid/duplicate): " . ($article['url'] ?? 'onbekende-url') . "\n";
                         }
                     }
                     
@@ -152,20 +154,25 @@ class NewsScraper {
         $newArticles = [];
         
         foreach ($articles as $article) {
+            $articleUrl = $this->normalizeArticleUrl($article['url'] ?? '');
+
+            if (!$this->isValidHttpUrl($articleUrl)) {
+                continue;
+            }
+
             // Stop zodra we een artikel vinden dat we al eerder hebben gezien
-            if ($article['url'] === $lastArticleUrl) {
+            if (!empty($lastArticleUrl) && $articleUrl === $lastArticleUrl) {
                 break;
             }
-            
+
             // Voeg metadata toe
+            $article['url'] = $articleUrl;
             $article['source'] = $sourceName;
             $article['orientation'] = $sourceConfig['orientation'];
             $article['bias'] = $sourceConfig['bias'];
-            
-            // Controleer of artikel al in database staat
-            if (!$this->articleExistsInDatabase($article['url'])) {
-                $newArticles[] = $article;
-            }
+            $article['publishedAt'] = $this->normalizePublishedAt($article['publishedAt'] ?? '');
+
+            $newArticles[] = $article;
         }
         
         return $newArticles;
@@ -204,6 +211,56 @@ class NewsScraper {
         file_put_contents($this->lastScrapedFile, json_encode($data, JSON_PRETTY_PRINT));
     }
     
+    private function normalizePublishedAt($publishedAt) {
+        $timestamp = strtotime((string)$publishedAt);
+        if ($timestamp === false) {
+            return date('Y-m-d H:i:s');
+        }
+
+        return date('Y-m-d H:i:s', $timestamp);
+    }
+
+    private function isValidHttpUrl($url) {
+        if (empty($url) || !filter_var($url, FILTER_VALIDATE_URL)) {
+            return false;
+        }
+
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        return in_array(strtolower((string)$scheme), ['http', 'https'], true);
+    }
+
+    private function normalizeArticleUrl($url) {
+        if (!is_string($url)) {
+            return '';
+        }
+
+        $url = trim($url);
+        if ($url === '') {
+            return '';
+        }
+
+        $parts = parse_url($url);
+        if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+            return $url;
+        }
+
+        $query = '';
+        if (!empty($parts['query'])) {
+            parse_str($parts['query'], $queryParams);
+            foreach (array_keys($queryParams) as $key) {
+                if (stripos($key, 'utm_') === 0 || in_array(strtolower($key), ['fbclid', 'gclid'], true)) {
+                    unset($queryParams[$key]);
+                }
+            }
+            if (!empty($queryParams)) {
+                $query = '?' . http_build_query($queryParams);
+            }
+        }
+
+        $path = $parts['path'] ?? '/';
+        return strtolower($parts['scheme']) . '://' . strtolower($parts['host']) . $path . $query;
+    }
+
     /**
      * Clean up oude artikelen (ouder dan X dagen)
      */

--- a/models/NewsModel.php
+++ b/models/NewsModel.php
@@ -140,13 +140,45 @@ class NewsModel {
      * Voeg een nieuw artikel toe
      */
     public function addNewsArticle($title, $description, $url, $source, $bias, $orientation, $publishedAt) {
-        $sql = "INSERT INTO news_articles (title, description, url, source, bias, orientation, published_at) VALUES (?, ?, ?, ?, ?, ?, ?)";
-        
+        $normalizedUrl = $this->normalizeUrl($url);
+
+        if (!$this->isValidHttpUrl($normalizedUrl)) {
+            error_log("NewsModel::addNewsArticle overgeslagen, ongeldige URL: " . $url);
+            return false;
+        }
+
         try {
+            // Idempotent: update bestaand artikel op dezelfde URL i.p.v. duplicaat inserten
+            $this->db->query("SELECT id, published_at FROM news_articles WHERE url = ? LIMIT 1");
+            $this->db->bind(1, $normalizedUrl);
+            $this->db->execute();
+            $existing = $this->db->single();
+
+            if ($existing) {
+                $existingPublished = strtotime($existing->published_at ?? '1970-01-01 00:00:00');
+                $incomingPublished = strtotime($publishedAt ?: '1970-01-01 00:00:00');
+
+                // Alleen upgraden als inkomende data recenter is of missende velden vult
+                if ($incomingPublished >= $existingPublished || empty($existing->published_at)) {
+                    $this->db->query("UPDATE news_articles SET title = ?, description = ?, source = ?, bias = ?, orientation = ?, published_at = ? WHERE id = ?");
+                    $this->db->bind(1, $title);
+                    $this->db->bind(2, $description);
+                    $this->db->bind(3, $source);
+                    $this->db->bind(4, $bias);
+                    $this->db->bind(5, $orientation);
+                    $this->db->bind(6, $publishedAt);
+                    $this->db->bind(7, intval($existing->id));
+                    $this->db->execute();
+                }
+
+                return true;
+            }
+
+            $sql = "INSERT INTO news_articles (title, description, url, source, bias, orientation, published_at) VALUES (?, ?, ?, ?, ?, ?, ?)";
             $this->db->query($sql);
             $this->db->bind(1, $title);
             $this->db->bind(2, $description);
-            $this->db->bind(3, $url);
+            $this->db->bind(3, $normalizedUrl);
             $this->db->bind(4, $source);
             $this->db->bind(5, $bias);
             $this->db->bind(6, $orientation);
@@ -248,10 +280,107 @@ class NewsModel {
     }
     
     /**
+     * Haal recente artikelen op per perspectief op voor homepage
+     */
+    public function getHomepageNews($perOrientation = 3, $maxAgeHours = 48) {
+        $result = [
+            'links' => [],
+            'rechts' => []
+        ];
+
+        foreach (['links', 'rechts'] as $orientation) {
+            $result[$orientation] = $this->getRecentNewsByOrientation($orientation, $perOrientation, $maxAgeHours);
+
+            // Fallback: als er te weinig recente items zijn, pak laatste items zonder tijdsfilter
+            if (count($result[$orientation]) < $perOrientation) {
+                $fallback = $this->getNewsByOrientation($orientation, $perOrientation);
+                $merged = array_merge($result[$orientation], $fallback);
+
+                // Uniek op URL en terugknippen
+                $unique = [];
+                foreach ($merged as $article) {
+                    $key = $article['url'] ?? md5(json_encode($article));
+                    if (!isset($unique[$key])) {
+                        $unique[$key] = $article;
+                    }
+                }
+
+                $result[$orientation] = array_slice(array_values($unique), 0, $perOrientation);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Recente artikelen per oriëntatie met tijdsfilter
+     */
+    public function getRecentNewsByOrientation($orientation, $limit = 3, $maxAgeHours = 48) {
+        $sql = "SELECT * FROM news_articles WHERE orientation = ? AND published_at >= DATE_SUB(NOW(), INTERVAL ? HOUR) ORDER BY published_at DESC LIMIT ?";
+
+        try {
+            $this->db->query($sql);
+            $this->db->bind(1, $orientation);
+            $this->db->bind(2, intval($maxAgeHours));
+            $this->db->bind(3, intval($limit));
+            $this->db->execute();
+            return $this->formatNewsResultsFromObject($this->db->resultSet());
+        } catch (Exception $e) {
+            error_log("NewsModel::getRecentNewsByOrientation fout: " . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
      * Geef toegang tot database object voor NewsScraper
      */
     public function getDatabase() {
         return $this->db;
+    }
+
+    private function isValidHttpUrl($url) {
+        if (empty($url) || !filter_var($url, FILTER_VALIDATE_URL)) {
+            return false;
+        }
+
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        return in_array(strtolower((string)$scheme), ['http', 'https'], true);
+    }
+
+    private function normalizeUrl($url) {
+        if (!is_string($url)) {
+            return '';
+        }
+
+        $url = trim($url);
+        if ($url === '') {
+            return '';
+        }
+
+        $parts = parse_url($url);
+        if ($parts === false || empty($parts['host']) || empty($parts['scheme'])) {
+            return $url;
+        }
+
+        $scheme = strtolower($parts['scheme']);
+        $host = strtolower($parts['host']);
+        $path = $parts['path'] ?? '/';
+
+        // Strip tracking query params maar behoud inhoudelijke params
+        $query = '';
+        if (!empty($parts['query'])) {
+            parse_str($parts['query'], $queryParams);
+            foreach (array_keys($queryParams) as $key) {
+                if (stripos($key, 'utm_') === 0 || in_array(strtolower($key), ['fbclid', 'gclid'], true)) {
+                    unset($queryParams[$key]);
+                }
+            }
+            if (!empty($queryParams)) {
+                $query = '?' . http_build_query($queryParams);
+            }
+        }
+
+        return $scheme . '://' . $host . $path . $query;
     }
 }
 ?> 


### PR DESCRIPTION
## Incident fix\nHomepage-sectie 'Laatste Politiek Nieuws' gebruikte hardcoded artikelen i.p.v. DB + scraper output.\n\n## Wat is aangepast\n- Home controller haalt nu per perspectief recente artikelen uit  via \n- Robuuste fallback + logging toegevoegd als een perspectief te weinig recente items heeft\n- Noodfallback toegevoegd zodat sectie nooit leeg rendert\n- NewsScraper bronnen geüpdatet naar politieke RSS endpoints\n- AD oriëntatie hersteld naar  voor consistente rendering\n- URL-normalisatie + tracking-parameter stripping toegevoegd\n- Idempotente upsert-flow in  op basis van URL\n\n## Testplan\n- [ ] \n- [ ] \n- [ ] \n- [ ] \n- [ ] Homepage check: 3+3 recente artikelen met externe links\n