### PR TITLE
fix(api): laad JWT secret uit environment met productie fail-fast

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -457,6 +457,15 @@ Alle endpoints hebben consistente foutafhandeling met duidelijke error messages 
 - **Geldigheid**: 24 uur
 - **Algoritme**: HS256
 - **Refresh**: Gebruik `/api/auth/refresh` endpoint
+- **Secret config**: zet `POLITIEKPRAAT_JWT_SECRET` als environment variable (minimaal 32 random tekens)
+- **Fail-fast productie**: API stopt in productie als `POLITIEKPRAAT_JWT_SECRET` ontbreekt
+
+### JWT secret rotatie (zonder downtime)
+
+1. Genereer een nieuwe sterke secret (minimaal 32 tekens) en zet die in `POLITIEKPRAAT_JWT_SECRET`.
+2. Deploy de wijziging en herstart PHP-FPM/webserver zodat de nieuwe env actief is.
+3. Houd rekening met max. 24 uur overlap: bestaande tokens met oude secret verlopen vanzelf binnen de TTL.
+4. Na 24 uur zijn alle oude tokens ongeldig; forceer desgewenst eerder herauthenticatie via logout/session reset.
 
 ## Voorbeelden
 

--- a/api/endpoints/auth.php
+++ b/api/endpoints/auth.php
@@ -10,8 +10,7 @@ class AuthAPI {
         $this->db = new Database();
         $this->authController = new AuthController();
         
-        // JWT secret key - in productie moet dit in een config file
-        $this->secretKey = 'PolitiekPraat_JWT_Secret_2024_Secure_Key_' . (defined('DB_NAME') ? DB_NAME : 'default');
+        $this->secretKey = JwtService::resolveSecretKey();
         $this->jwtService = new JwtService($this->secretKey);
     }
     

--- a/includes/JwtService.php
+++ b/includes/JwtService.php
@@ -5,10 +5,33 @@ class JwtService {
 
     public function __construct($secret_key = null) {
         if ($secret_key === null) {
-            $secret_key = 'PolitiekPraat_JWT_Secret_2024_Secure_Key_' . (defined('DB_NAME') ? DB_NAME : 'default');
+            $secret_key = self::resolveSecretKey();
         }
 
         $this->secret_key = $secret_key;
+    }
+
+    public static function resolveSecretKey() {
+        $secret = getenv('POLITIEKPRAAT_JWT_SECRET');
+
+        if (is_string($secret)) {
+            $secret = trim($secret);
+        }
+
+        if (is_string($secret) && $secret !== '') {
+            return $secret;
+        }
+
+        $app_env = defined('APP_ENV') ? APP_ENV : strtolower((string) (getenv('APP_ENV') ?: 'production'));
+        $is_production = !in_array($app_env, ['local', 'development', 'dev', 'test', 'testing', 'staging'], true);
+
+        if ($is_production) {
+            throw new RuntimeException('POLITIEKPRAAT_JWT_SECRET ontbreekt. Zet een sterke secret in de environment voordat de API start.');
+        }
+
+        trigger_error('POLITIEKPRAAT_JWT_SECRET ontbreekt; development fallback actief. Zet alsnog een lokale secret voor consistente tests.', E_USER_WARNING);
+
+        return 'dev-only-jwt-secret-change-me';
     }
 
     public function verify($token) {


### PR DESCRIPTION
Closes #62

## Wijzigingen
- Hardcoded JWT secret verwijderd uit `api/endpoints/auth.php` en `includes/JwtService.php`
- JWT secret wordt nu geladen via `POLITIEKPRAAT_JWT_SECRET`
- Productie faalt direct (RuntimeException) als de secret ontbreekt
- Alleen in niet-productie omgevingen: expliciete warning + development fallback
- Rotatieprocedure toegevoegd aan `api/README.md`

## Gewijzigde bestanden
- `includes/JwtService.php` - centrale secret-resolutie + fail-fast policy
- `api/endpoints/auth.php` - gebruikt gedeelde secret-resolutie
- `api/README.md` - documentatie voor env-config en secret-rotatie

## Test plan
- [ ] `php -l includes/JwtService.php`
- [ ] `php -l api/endpoints/auth.php`
- [ ] Met `APP_ENV=production` en zonder `POLITIEKPRAAT_JWT_SECRET`: API stopt met duidelijke fout
- [ ] Met geldige `POLITIEKPRAAT_JWT_SECRET`: login/verify/refresh werken
- [ ] Geen debug output in response

_Note: lokale `php -l` kon in deze runner niet uitgevoerd worden omdat `php` CLI ontbreekt._
