### PR TITLE
perf(views): paginate /blogs and trim client JS payload

### DIFF
--- a/controllers/blogs.php
+++ b/controllers/blogs.php
@@ -10,19 +10,39 @@ class BlogsController {
         // Check for category filtering via query parameter
         $categoryId = null;
         $selectedCategory = null;
-        
+
         if (isset($_GET['category'])) {
             $categoryController = new CategoryController();
             $selectedCategory = $categoryController->getBySlug($_GET['category']);
-            
+
             if ($selectedCategory) {
                 $categoryId = $selectedCategory->id;
             }
         }
-        
+
+        $currentPage = isset($_GET['page']) ? (int) $_GET['page'] : 1;
+        if ($currentPage < 1) {
+            $currentPage = 1;
+        }
+
+        $perPage = 9;
+        $totalBlogs = $this->blogModel->getTotalBlogCount($categoryId);
+        $totalPages = (int) ceil($totalBlogs / $perPage);
+
+        if ($totalPages > 0 && $currentPage > $totalPages) {
+            $currentPage = $totalPages;
+        }
+
         // Get blogs with optional category filtering
-        $blogs = $this->blogModel->getAll(null, $categoryId);
-        
+        $blogs = $this->blogModel->getPaginated($currentPage, $perPage, $categoryId);
+
+        $paginationData = [
+            'currentPage' => $currentPage,
+            'totalPages' => $totalPages,
+            'perPage' => $perPage,
+            'totalBlogs' => $totalBlogs,
+        ];
+
         require_once BASE_PATH . '/views/blogs/index.php';
     }
     

--- a/includes/BlogController.php
+++ b/includes/BlogController.php
@@ -30,46 +30,91 @@ class BlogController {
     }
 
     public function getAll($limit = null, $categoryId = null) {
+        if ($limit) {
+            return $this->getPaginated(1, (int) $limit, $categoryId);
+        }
+
         $sql = "SELECT blogs.*, users.username as author_name, users.profile_photo as author_photo,
-                       blog_categories.name as category_name, blog_categories.slug as category_slug, 
+                       blog_categories.name as category_name, blog_categories.slug as category_slug,
                        blog_categories.color as category_color, blog_categories.icon as category_icon
-                FROM blogs 
-                JOIN users ON blogs.author_id = users.id 
+                FROM blogs
+                JOIN users ON blogs.author_id = users.id
                 LEFT JOIN blog_categories ON blogs.category_id = blog_categories.id";
-        
+
         if ($categoryId) {
             $sql .= " WHERE blogs.category_id = :category_id";
         }
-        
+
         $sql .= " ORDER BY published_at DESC";
-        
-        if ($limit) {
-            $sql .= " LIMIT " . intval($limit);
-        }
-        
+
         $this->db->query($sql);
-        
+
         if ($categoryId) {
             $this->db->bind(':category_id', $categoryId);
         }
-        
+
         $blogs = $this->db->resultSet();
-        
-        // Wijs consistente kleuren toe
+        return $this->hydrateBlogCollection($blogs);
+    }
+
+    public function getPaginated($page = 1, $perPage = 9, $categoryId = null) {
+        $page = max(1, (int) $page);
+        $perPage = max(1, (int) $perPage);
+        $offset = ($page - 1) * $perPage;
+
+        $sql = "SELECT blogs.*, users.username as author_name, users.profile_photo as author_photo,
+                       blog_categories.name as category_name, blog_categories.slug as category_slug,
+                       blog_categories.color as category_color, blog_categories.icon as category_icon
+                FROM blogs
+                JOIN users ON blogs.author_id = users.id
+                LEFT JOIN blog_categories ON blogs.category_id = blog_categories.id";
+
+        if ($categoryId) {
+            $sql .= " WHERE blogs.category_id = :category_id";
+        }
+
+        $sql .= " ORDER BY published_at DESC LIMIT :offset, :per_page";
+
+        $this->db->query($sql);
+
+        if ($categoryId) {
+            $this->db->bind(':category_id', $categoryId);
+        }
+
+        $this->db->bind(':offset', $offset, PDO::PARAM_INT);
+        $this->db->bind(':per_page', $perPage, PDO::PARAM_INT);
+
+        $blogs = $this->db->resultSet();
+        return $this->hydrateBlogCollection($blogs);
+    }
+
+    public function getTotalBlogCount($categoryId = null) {
+        $sql = "SELECT COUNT(*) as total FROM blogs";
+
+        if ($categoryId) {
+            $sql .= " WHERE category_id = :category_id";
+        }
+
+        $this->db->query($sql);
+
+        if ($categoryId) {
+            $this->db->bind(':category_id', $categoryId);
+        }
+
+        $result = $this->db->single();
+        return (int) ($result->total ?? 0);
+    }
+
+    private function hydrateBlogCollection($blogs) {
         $blogs = $this->categoryController->assignCategoryColors($blogs, true);
 
-        // Parse Markdown naar HTML voor elk blog
         foreach ($blogs as $blog) {
-            // Bewaar de originele content voor de samenvatting
             $originalContent = $blog->content;
-            // Converteer Markdown naar HTML voor de volledige content
             $blog->content = $this->parsedown->text($blog->content);
-            // Maak een samenvatting van de originele content
             $blog->summary = substr(strip_tags($this->parsedown->text($originalContent)), 0, 200) . '...';
-            // Bereken leestijd
             $blog->reading_time = $this->calculateReadingTime($originalContent);
         }
-        
+
         return $blogs;
     }
 

--- a/views/blogs/index.php
+++ b/views/blogs/index.php
@@ -469,44 +469,37 @@
                     <?php endif; ?>
                 </div>
             <?php endif; ?>
+
+            <?php if (!empty($paginationData) && ($paginationData['totalPages'] ?? 0) > 1): ?>
+                <?php
+                    $page = (int) ($paginationData['currentPage'] ?? 1);
+                    $totalPages = (int) ($paginationData['totalPages'] ?? 1);
+                    $baseParams = $_GET;
+                    unset($baseParams['page']);
+                    $baseQuery = http_build_query($baseParams);
+                    $baseUrl = URLROOT . '/blogs' . ($baseQuery ? '?' . $baseQuery . '&' : '?');
+                ?>
+                <nav class="mt-10 flex items-center justify-center gap-2" aria-label="Paginering blogs">
+                    <a href="<?php echo $page > 1 ? $baseUrl . 'page=' . ($page - 1) : '#'; ?>"
+                       class="inline-flex items-center px-3 py-2 rounded-lg border text-sm font-medium transition <?php echo $page > 1 ? 'border-gray-300 text-gray-700 hover:bg-gray-50' : 'border-gray-200 text-gray-300 pointer-events-none'; ?>">
+                        Vorige
+                    </a>
+
+                    <?php for ($i = max(1, $page - 2); $i <= min($totalPages, $page + 2); $i++): ?>
+                        <a href="<?php echo $baseUrl . 'page=' . $i; ?>"
+                           class="inline-flex items-center justify-center w-10 h-10 rounded-lg text-sm font-semibold transition <?php echo $i === $page ? 'bg-primary text-white shadow-md' : 'border border-gray-300 text-gray-700 hover:bg-gray-50'; ?>">
+                            <?php echo $i; ?>
+                        </a>
+                    <?php endfor; ?>
+
+                    <a href="<?php echo $page < $totalPages ? $baseUrl . 'page=' . ($page + 1) : '#'; ?>"
+                       class="inline-flex items-center px-3 py-2 rounded-lg border text-sm font-medium transition <?php echo $page < $totalPages ? 'border-gray-300 text-gray-700 hover:bg-gray-50' : 'border-gray-200 text-gray-300 pointer-events-none'; ?>">
+                        Volgende
+                    </a>
+                </nav>
+            <?php endif; ?>
         </div>
     </section>
 </main>
 
-<!-- Scripts voor Markdown parsing -->
-<script src="https://cdn.jsdelivr.net/npm/marked@4.3.0/marked.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/dompurify@2.3.3/dist/purify.min.js"></script>
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    // Configureer marked
-    marked.use({ 
-        breaks: true,
-        gfm: true,
-        headerIds: false
-    });
-
-    // Functie om markdown te parsen en te strippen van HTML tags
-    function parseAndStripMarkdown(markdown, length = 150) {
-        try {
-            // Parse markdown naar HTML
-            const html = marked.parse(markdown);
-            // Sanitize de HTML
-            const cleanHtml = DOMPurify.sanitize(html);
-            // Strip HTML tags en limiteer lengte
-            const text = cleanHtml.replace(/<[^>]*>/g, '');
-            return text.length > length ? text.substring(0, length) + '...' : text;
-        } catch (error) {
-            console.error('Markdown parsing error:', error);
-            return markdown;
-        }
-    }
-
-    // Pas toe op alle blog samenvattingen
-    document.querySelectorAll('.blog-summary').forEach(summary => {
-        const markdown = summary.textContent;
-        summary.textContent = parseAndStripMarkdown(markdown);
-    });
-});
-</script>
-
-<?php require_once 'views/templates/footer.php'; ?> 
+<?php require_once 'views/templates/footer.php'; ?>


### PR DESCRIPTION
Closes #66

## Wijzigingen
- Server-side paginering toegevoegd op `/blogs` (9 items per pagina)
- Nieuwe `getPaginated()` + `getTotalBlogCount()` in `BlogController` voor efficiënte query met `LIMIT/OFFSET`
- Pagination UI toegevoegd in de blogs index view, inclusief behoud van actieve query params (zoals category)
- Ongebruikte client-side Markdown scripts (`marked`/`dompurify`) verwijderd uit de index view om initiële HTML/JS payload te verlagen

## Gewijzigde bestanden
- `controllers/blogs.php` - paginering + paginationData in controller
- `includes/BlogController.php` - paginated fetch + totaal count + hydratie helper
- `views/blogs/index.php` - paginering navigatie + verwijderen overbodige scripts

## Test plan
- [x] Branch buildt en pusht zonder merge-conflicts
- [ ] `php -l` op gewijzigde bestanden
- [ ] `/blogs` toont max 9 kaarten op pagina 1
- [ ] `?page=2` toont volgende set blogs
- [ ] `?category=<slug>&page=2` behoudt category-filter
- [ ] Geen regressie op featured blog en cards layout

## Opmerking
`php` CLI is niet beschikbaar in deze runner (`php: command not found`), daarom kon syntax-lint niet lokaal uitgevoerd worden.
