### PR TITLE
fix(security): zet TLS-verificatie aan voor RSS cURL requests

### DIFF
--- a/includes/NewsAPI.php
+++ b/includes/NewsAPI.php
@@ -198,19 +198,37 @@ class NewsAPI {
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36');
             curl_setopt($ch, CURLOPT_TIMEOUT, 15); // Increase timeout
-            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
             
             // Voer het verzoek uit
             $response = curl_exec($ch);
             $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $curlErrno = curl_errno($ch);
             $error = curl_error($ch);
             
             // Sluit cURL
             curl_close($ch);
+
+            $source = $this->getSourceFromFeedUrl($feed_url);
+
+            if ($curlErrno !== 0) {
+                $isTlsError = stripos($error, 'ssl') !== false
+                    || stripos($error, 'tls') !== false
+                    || stripos($error, 'certificate') !== false;
+
+                if ($isTlsError) {
+                    error_log("RSS TLS-verificatie gefaald voor bron '{$source}' ({$feed_url}): cURL #{$curlErrno} {$error}");
+                } else {
+                    error_log("RSS cURL-fout voor bron '{$source}' ({$feed_url}): cURL #{$curlErrno} {$error}");
+                }
+
+                return [];
+            }
             
             // Controleer of we een geldige response hebben
             if ($httpCode !== 200 || !$response) {
-                throw new Exception("Kon feed niet ophalen: HTTP code " . $httpCode . " Error: " . $error);
+                throw new Exception("Kon feed niet ophalen voor bron '" . $source . "': HTTP code " . $httpCode);
             }
 
             // Fix mogelijk slecht gevormde XML (geldt ook voor sommige WordPress/CDN feeds)


### PR DESCRIPTION
Closes #58

## Wijzigingen
- CURLOPT_SSL_VERIFYPEER verplicht op true gezet voor alle RSS cURL-calls
- CURLOPT_SSL_VERIFYHOST op 2 gezet voor hostnaam-validatie
- cURL error handling uitgebreid met fail-fast per bron (return [] i.p.v. globale crash)
- Logging verbeterd met bronnaam + foutreden, inclusief expliciete TLS-foutdetectie
- HTTP-foutmelding opgeschoond zodat geen onnodige ruwe cURL-fouttekst wordt doorgeschoten in exceptions

## Gewijzigde bestanden
- includes/NewsAPI.php - TLS hardening + veilige foutafhandeling per feed-bron

## Test plan
- [x] Codepad gecontroleerd: bij cURL TLS-fout wordt bron overgeslagen ([]) en proces crasht niet
- [x] Handmatige review dat TLS peer+host verificatie nu expliciet aan staat
- [ ] php -l includes/NewsAPI.php (niet uitvoerbaar in huidige runner: php binary ontbreekt)
