### PR TITLE
fix(db): voorkom PDO error detail leaks in output (#75)

### DIFF
--- a/includes/Database.php
+++ b/includes/Database.php
@@ -17,9 +17,16 @@ class Database {
 
         try {
             $this->dbh = new PDO($dsn, $this->user, $this->pass, $options);
-        } catch(PDOException $e) {
-            $this->error = $e->getMessage();
-            echo $this->error;
+        } catch (PDOException $e) {
+            $this->error = 'Database connection failed';
+            error_log(sprintf(
+                '[Database] Connection failed: %s in %s:%d',
+                $e->getMessage(),
+                $e->getFile(),
+                $e->getLine()
+            ));
+
+            throw new RuntimeException('Er is een tijdelijk databaseprobleem. Probeer het later opnieuw.');
         }
     }
 


### PR DESCRIPTION
Closes #75

## Wijzigingen
- Verwijdert directe output van PDO exception details in `Database::__construct()`.
- Logt verbindingsdetails alleen server-side via `error_log()` met context (bestand/regel).
- Gooit een generieke `RuntimeException` zonder technische details voor eindgebruikers.

## Gewijzigde bestanden
- `includes/Database.php` - veilige afhandeling van database-connectiefouten zonder detaillek.

## Test plan
- [x] Handmatige code-inspectie: geen `echo`/`print` van PDO-fouten meer.
- [x] Branch pushed en diff gecontroleerd op alleen beoogde wijziging.
- [ ] Runtime test met geforceerde DB-fout (lokaal niet uitgevoerd: `php` CLI ontbreekt op deze runner).
