### PR TITLE
fix(api): sanitize exception details in public error responses

### DIFF
--- a/api/endpoints/auth.php
+++ b/api/endpoints/auth.php
@@ -316,11 +316,10 @@ class AuthAPI {
     
     private function sendError($message, $statusCode = 400) {
         http_response_code($statusCode);
-        echo json_encode([
-            'success' => false,
-            'error' => $message,
-            'timestamp' => date('c')
-        ], JSON_UNESCAPED_UNICODE);
+        echo json_encode(
+            api_build_error_response($message, (int) $statusCode),
+            JSON_UNESCAPED_UNICODE
+        );
         exit();
     }
 } 

--- a/api/endpoints/blogs.php
+++ b/api/endpoints/blogs.php
@@ -496,11 +496,10 @@ class BlogsAPI {
     
     private function sendError($message, $statusCode = 400) {
         http_response_code($statusCode);
-        echo json_encode([
-            'success' => false,
-            'error' => $message,
-            'timestamp' => date('c')
-        ], JSON_UNESCAPED_UNICODE);
+        echo json_encode(
+            api_build_error_response($message, (int) $statusCode),
+            JSON_UNESCAPED_UNICODE
+        );
         exit();
     }
 } 

--- a/api/endpoints/news.php
+++ b/api/endpoints/news.php
@@ -328,11 +328,10 @@ class NewsAPI {
     
     private function sendError($message, $statusCode = 400) {
         http_response_code($statusCode);
-        echo json_encode([
-            'success' => false,
-            'error' => $message,
-            'timestamp' => date('c')
-        ], JSON_UNESCAPED_UNICODE);
+        echo json_encode(
+            api_build_error_response($message, (int) $statusCode),
+            JSON_UNESCAPED_UNICODE
+        );
         exit();
     }
 } 

--- a/api/endpoints/user.php
+++ b/api/endpoints/user.php
@@ -459,11 +459,10 @@ class UserAPI {
     
     private function sendError($message, $statusCode = 400) {
         http_response_code($statusCode);
-        echo json_encode([
-            'success' => false,
-            'error' => $message,
-            'timestamp' => date('c')
-        ], JSON_UNESCAPED_UNICODE);
+        echo json_encode(
+            api_build_error_response($message, (int) $statusCode),
+            JSON_UNESCAPED_UNICODE
+        );
         exit();
     }
 } 

--- a/api/index.php
+++ b/api/index.php
@@ -6,6 +6,7 @@ if (!defined('API_DEBUG')) {
 
 require_once __DIR__ . '/../includes/cors.php';
 require_once __DIR__ . '/../includes/rate_limiter.php';
+require_once __DIR__ . '/../includes/api_error_helpers.php';
 
 // Set headers voor API responses
 header('Content-Type: application/json; charset=UTF-8');
@@ -35,17 +36,10 @@ function debug_log($message) {
 // Error handler functie
 function sendApiError($message, $statusCode = 500, $debug = null) {
     http_response_code($statusCode);
-    $response = [
-        'success' => false,
-        'error' => $message,
-        'timestamp' => date('c')
-    ];
-    
-    if ($debug && defined('API_DEBUG') && API_DEBUG) {
-        $response['debug'] = $debug;
-    }
-    
-    echo json_encode($response, JSON_UNESCAPED_UNICODE);
+    echo json_encode(
+        api_build_error_response($message, (int) $statusCode, $debug),
+        JSON_UNESCAPED_UNICODE
+    );
     exit();
 }
 

--- a/includes/api_error_helpers.php
+++ b/includes/api_error_helpers.php
@@ -1,0 +1,84 @@
+<?php
+
+if (!function_exists('api_get_request_id')) {
+    function api_get_request_id(): string {
+        static $requestId = null;
+
+        if ($requestId !== null) {
+            return $requestId;
+        }
+
+        $incoming = $_SERVER['HTTP_X_REQUEST_ID'] ?? '';
+        if (is_string($incoming) && preg_match('/^[a-zA-Z0-9._-]{8,100}$/', $incoming)) {
+            $requestId = $incoming;
+            return $requestId;
+        }
+
+        try {
+            $requestId = bin2hex(random_bytes(8));
+        } catch (Exception $e) {
+            $requestId = uniqid('req_', true);
+        }
+
+        return $requestId;
+    }
+}
+
+if (!function_exists('api_can_show_diagnostics')) {
+    function api_can_show_diagnostics(): bool {
+        return function_exists('can_access_diagnostics') ? can_access_diagnostics() : false;
+    }
+}
+
+if (!function_exists('api_public_error_message')) {
+    function api_public_error_message($message, int $statusCode): string {
+        if ($statusCode >= 500 && !api_can_show_diagnostics()) {
+            return 'Interne serverfout';
+        }
+
+        return (string) $message;
+    }
+}
+
+if (!function_exists('api_log_error_details')) {
+    function api_log_error_details(string $publicMessage, int $statusCode, $debug = null): void {
+        if ($statusCode < 500) {
+            return;
+        }
+
+        $requestId = api_get_request_id();
+        $context = [
+            'request_id' => $requestId,
+            'status' => $statusCode,
+            'method' => $_SERVER['REQUEST_METHOD'] ?? 'CLI',
+            'uri' => $_SERVER['REQUEST_URI'] ?? '',
+            'public_error' => $publicMessage,
+        ];
+
+        if ($debug !== null) {
+            $context['debug'] = $debug;
+        }
+
+        error_log('[API ERROR] ' . json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+}
+
+if (!function_exists('api_build_error_response')) {
+    function api_build_error_response($message, int $statusCode = 500, $debug = null): array {
+        $publicMessage = api_public_error_message($message, $statusCode);
+        api_log_error_details((string) $message, $statusCode, $debug);
+
+        $response = [
+            'success' => false,
+            'error' => $publicMessage,
+            'timestamp' => date('c'),
+            'request_id' => api_get_request_id(),
+        ];
+
+        if ($debug !== null && api_can_show_diagnostics()) {
+            $response['debug'] = $debug;
+        }
+
+        return $response;
+    }
+}

--- a/scripts/tests/test-api-error-sanitization.php
+++ b/scripts/tests/test-api-error-sanitization.php
@@ -1,0 +1,33 @@
+<?php
+
+require_once __DIR__ . '/../../includes/api_error_helpers.php';
+
+function assert_true($condition, $message) {
+    if (!$condition) {
+        fwrite(STDERR, "FAIL: {$message}\n");
+        exit(1);
+    }
+}
+
+$_SERVER['REQUEST_METHOD'] = 'GET';
+$_SERVER['REQUEST_URI'] = '/api/test';
+$_SERVER['HTTP_X_REQUEST_ID'] = 'req-test-1234';
+
+$payload500 = api_build_error_response('SQLSTATE[42S22]: Unknown column users.password', 500, ['file' => '/var/www/private.php']);
+assert_true($payload500['success'] === false, 'success moet false zijn');
+assert_true($payload500['error'] === 'Interne serverfout', '500 fouten mogen geen interne details lekken');
+assert_true($payload500['request_id'] === 'req-test-1234', 'request_id moet uit header komen');
+
+$payload400 = api_build_error_response('Ongeldige parameter: page', 400);
+assert_true($payload400['error'] === 'Ongeldige parameter: page', '4xx foutmelding mag behouden blijven');
+
+// Simuleer debug/diagnostics mode
+function can_access_diagnostics(): bool {
+    return true;
+}
+
+$payload500Debug = api_build_error_response('SQLSTATE test detail', 500, ['query' => 'SELECT *']);
+assert_true($payload500Debug['error'] === 'SQLSTATE test detail', 'in diagnostics mode mag detail zichtbaar zijn');
+assert_true(isset($payload500Debug['debug']), 'debug payload moet aanwezig zijn in diagnostics mode');
+
+echo "OK: api error sanitization regressietest geslaagd\n";


### PR DESCRIPTION
Closes #80

## Wijzigingen
- Centrale API error-helper toegevoegd (`includes/api_error_helpers.php`) met request-id generatie en veilige error mapping.
- `sendApiError()` in `api/index.php` gebruikt nu de centrale helper, zodat 5xx-responses in productie generiek blijven en interne details niet lekken.
- Endpoint-specifieke `sendError()` responses in `api/endpoints/auth.php`, `api/endpoints/blogs.php`, `api/endpoints/news.php` en `api/endpoints/user.php` laten nu ook dezelfde veilige mapping lopen.
- Regressietest toegevoegd: `scripts/tests/test-api-error-sanitization.php`.

## Security gedrag
- 5xx responses: generieke `Interne serverfout` (tenzij diagnostics/debug actief is).
- 4xx responses: bestaande functionele foutmeldingen blijven zichtbaar.
- Alle 5xx fouten worden intern gelogd met `request_id`, status, method en uri.
- API error payload bevat voortaan ook `request_id` voor support/correlatie.

## Test plan
- [ ] `php -l` op gewijzigde PHP-bestanden
- [ ] `php scripts/tests/test-api-error-sanitization.php`
- [ ] Smoke: geforceerde 500 op endpoint geeft geen exception details terug
- [ ] 4xx contract blijft gelijk (`success=false`, functionele foutmelding)

> Let op: in deze runner is `php` niet beschikbaar (`php: command not found`), dus lint/run moeten in CI of op host met PHP worden bevestigd.
