### PR TITLE
security(frontend): verwijder debug session output uit footer

### DIFF
--- a/views/templates/footer.php
+++ b/views/templates/footer.php
@@ -348,13 +348,6 @@
         });
     </script>
 
-    <?php if (isAdmin() && isset($_GET['debug_photo'])): ?>
-    <div class="fixed bottom-0 right-0 bg-black/80 text-white p-4 rounded-tl-lg text-xs font-mono max-w-lg overflow-auto max-h-64">
-        <h3 class="font-bold mb-2">Profile Photo Debug:</h3>
-        <?php print_r($_SESSION['profile_photo_debug'] ?? 'No debug info available'); ?>
-    </div>
-    <?php endif; ?>
-
     <!-- Dynamic Scripts -->
     <?php if (basename($_SERVER['PHP_SELF']) == 'blogs.php' || strpos($_SERVER['REQUEST_URI'], '/blogs/') !== false): ?>
         <script src="<?php echo URLROOT; ?>/js/blog_likes.js"></script>


### PR DESCRIPTION
Closes #95

## Wijzigingen
- Debug-overlay in `views/templates/footer.php` verwijderd
- `print_r($_SESSION['profile_photo_debug'])` verwijderd uit productie-template

## Waarom
Deze debug-output kon interne sessiedata/padinformatie tonen op publieke pagina's.

## Test plan
- [x] Bevestigd dat debug block niet meer in footer-template staat
- [x] Geen `debug_photo`/`profile_photo_debug`/`print_r` referenties meer in `footer.php`
- [ ] `php -l views/templates/footer.php` (niet uitvoerbaar op deze host: `php` ontbreekt)
