### PR TITLE
fix(api): laad JWT secret uit gitignored env.local.php (#108)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ sitemap.xml
 # Lokale devteam state
 admin/devteam-state.json
 admin/devteam-queue.json
+
+# Lokale environment variabelen
+/includes/env.local.php

--- a/includes/JwtService.php
+++ b/includes/JwtService.php
@@ -12,6 +12,8 @@ class JwtService {
     }
 
     public static function resolveSecretKey() {
+        self::loadLocalEnvFallback();
+
         $secret = getenv('POLITIEKPRAAT_JWT_SECRET');
 
         if (is_string($secret)) {
@@ -32,6 +34,19 @@ class JwtService {
         trigger_error('POLITIEKPRAAT_JWT_SECRET ontbreekt; development fallback actief. Zet alsnog een lokale secret voor consistente tests.', E_USER_WARNING);
 
         return 'dev-only-jwt-secret-change-me';
+    }
+
+    private static function loadLocalEnvFallback() {
+        if (!empty(getenv('POLITIEKPRAAT_JWT_SECRET'))) {
+            return;
+        }
+
+        $base_path = defined('BASE_PATH') ? BASE_PATH : dirname(__DIR__);
+        $local_env_file = rtrim($base_path, '/\\') . '/includes/env.local.php';
+
+        if (is_readable($local_env_file)) {
+            require_once $local_env_file;
+        }
     }
 
     public function verify($token) {


### PR DESCRIPTION
## Probleem

`/api/blogs` gaf HTTP 500 bij elke request na een git pull, omdat `POLITIEKPRAAT_JWT_SECRET` ontbrak in de server environment.

Elke git pull reset `.htaccess`, waardoor de `SetEnv` directive verdween.

## Oplossing

**JwtService.php** laadt nu automatisch een gitignored `includes/env.local.php` als fallback wanneer de env var niet via de server is gezet:

```php
$localEnv = (defined("BASE_PATH") ? BASE_PATH : __DIR__) . "/includes/env.local.php";
if (file_exists($localEnv) && empty(getenv("POLITIEKPRAAT_JWT_SECRET"))) {
    require_once $localEnv;
}
```

**Deployment:** Eénmalig aanmaken op de server:
```bash
cat > /path/to/public_html/includes/env.local.php << EOF
<?php
if (empty(getenv("POLITIEKPRAAT_JWT_SECRET"))) {
    putenv("POLITIEKPRAAT_JWT_SECRET=jouw-sterke-secret");
}
EOF
```

Dit bestand is gitignored en overleeft alle toekomstige git pulls.

## Checklist
- [x] `includes/env.local.php` toegevoegd aan `.gitignore`
- [x] `JwtService::resolveSecretKey()` laadt de lokale fallback
- [x] API geeft 200 na de fix
- [x] Closes #108