### PR TITLE
security(api): fix blogs API-key owner mapping + scope checks

### DIFF
--- a/admin/devteam-state.json
+++ b/admin/devteam-state.json
@@ -1,0 +1,24 @@
+{
+  "last_techlead_run": {
+    "ts": "2026-03-22T13:54:00+01:00",
+    "role": "Tech Lead",
+    "summary": "Codebase scan afgerond, open issues gecheckt, nieuwe issues #105 #106 #107 aangemaakt.",
+    "top3_today": [
+      105,
+      106,
+      103
+    ],
+    "blockers": [
+      "Issue #20 workflow token scope blijft blocker voor CI/workflow push"
+    ],
+    "team_chat_reviewed": true
+  },
+  "last_developer_run": {
+    "ts": "2026-03-23T09:16:00+01:00",
+    "role": "Developer",
+    "issue": 110,
+    "branch": "dev/issue-110-api-key-owner-scope",
+    "summary": "Hardcoded admin-impersonatie verwijderd in blogs API-key auth; key-owner user mapping + scope checks + audit logging toegevoegd.",
+    "status": "in_review"
+  }
+}

--- a/api/endpoints/blogs.php
+++ b/api/endpoints/blogs.php
@@ -4,6 +4,12 @@ class BlogsAPI {
     private $db;
     private $blogController;
     private $jwtService;
+    private $authContext = [
+        'source' => null,
+        'api_key_id' => null,
+        'api_key_owner_id' => null,
+        'api_key_scopes' => []
+    ];
     
     public function __construct() {
         $this->db = new Database();
@@ -169,6 +175,8 @@ class BlogsAPI {
         if (!$user) {
             $this->sendError('Authenticatie vereist', 401);
         }
+
+        $this->assertApiKeyScope('blogs:create');
         
         $input = $this->getJsonInput();
         if (!$input) {
@@ -234,6 +242,8 @@ class BlogsAPI {
                                  WHERE blogs.id = :id");
                 $this->db->bind(':id', $blogId);
                 $newBlog = $this->db->single();
+
+                $this->auditApiKeyWrite('blogs:create', (int)$blogId, (int)$user->id);
                 
                 $this->sendResponse([
                     'message' => 'Blog succesvol aangemaakt',
@@ -266,6 +276,9 @@ class BlogsAPI {
         if ($existingBlog->author_id != $user->id && !$user->is_admin) {
             $this->sendError('Geen toestemming om deze blog te bewerken', 403);
         }
+
+        $requiredScope = ((int)$existingBlog->author_id === (int)$user->id) ? 'blogs:update:self' : 'blogs:update:any';
+        $this->assertApiKeyScope($requiredScope);
         
         $input = $this->getJsonInput();
         if (!$input) {
@@ -311,6 +324,8 @@ class BlogsAPI {
                                  WHERE blogs.id = :id");
                 $this->db->bind(':id', $id);
                 $updatedBlog = $this->db->single();
+
+                $this->auditApiKeyWrite('blogs:update', (int)$id, (int)$user->id);
                 
                 $this->sendResponse([
                     'message' => 'Blog succesvol bijgewerkt',
@@ -343,12 +358,16 @@ class BlogsAPI {
         if ($existingBlog->author_id != $user->id && !$user->is_admin) {
             $this->sendError('Geen toestemming om deze blog te verwijderen', 403);
         }
+
+        $requiredScope = ((int)$existingBlog->author_id === (int)$user->id) ? 'blogs:delete:self' : 'blogs:delete:any';
+        $this->assertApiKeyScope($requiredScope);
         
         try {
             $this->db->query("DELETE FROM blogs WHERE id = :id");
             $this->db->bind(':id', $id);
             
             if ($this->db->execute()) {
+                $this->auditApiKeyWrite('blogs:delete', (int)$id, (int)$user->id);
                 $this->sendResponse([
                     'message' => 'Blog succesvol verwijderd'
                 ]);
@@ -436,6 +455,12 @@ class BlogsAPI {
     private function getAuthenticatedUser() {
         $user = $this->getCurrentUserFromToken();
         if ($user) {
+            $this->authContext = [
+                'source' => 'token',
+                'api_key_id' => null,
+                'api_key_owner_id' => null,
+                'api_key_scopes' => []
+            ];
             return $user;
         }
 
@@ -476,8 +501,24 @@ class BlogsAPI {
         $keyHash = hash('sha256', $apiKey);
 
         try {
+            $scopeColumns = $this->detectApiKeyScopeColumns();
+            $selectParts = [
+                'ak.id',
+                'ak.user_id',
+                'u.id AS id',
+                'u.username',
+                'u.email',
+                'u.is_admin',
+                'u.profile_photo',
+                'u.created_at'
+            ];
+
+            foreach ($scopeColumns as $column) {
+                $selectParts[] = 'ak.' . $column;
+            }
+
             $this->db->query(
-                "SELECT id FROM api_keys WHERE key_hash = :key_hash AND is_active = 1 LIMIT 1"
+                'SELECT ' . implode(', ', $selectParts) . ' FROM api_keys ak JOIN users u ON u.id = ak.user_id WHERE ak.key_hash = :key_hash AND ak.is_active = 1 LIMIT 1'
             );
             $this->db->bind(':key_hash', $keyHash);
             $apiKeyRecord = $this->db->single();
@@ -486,20 +527,106 @@ class BlogsAPI {
                 return null;
             }
 
-            // Update last_used_at
             $this->db->query("UPDATE api_keys SET last_used_at = NOW() WHERE id = :id");
             $this->db->bind(':id', $apiKeyRecord->id);
             $this->db->execute();
 
-            // Always return user naoufal (ID=1)
-            $this->db->query(
-                "SELECT id, username, email, is_admin, profile_photo, created_at FROM users WHERE id = 1 LIMIT 1"
-            );
-            return $this->db->single();
+            $this->authContext = [
+                'source' => 'api_key',
+                'api_key_id' => (int) $apiKeyRecord->id,
+                'api_key_owner_id' => (int) $apiKeyRecord->user_id,
+                'api_key_scopes' => $this->extractApiKeyScopes($apiKeyRecord, $scopeColumns)
+            ];
+
+            return $apiKeyRecord;
 
         } catch (Exception $e) {
             return null;
         }
+    }
+
+    private function detectApiKeyScopeColumns() {
+        $columns = [];
+        foreach (['scope', 'scopes', 'permissions'] as $candidate) {
+            $this->db->query("SHOW COLUMNS FROM api_keys LIKE :column_name");
+            $this->db->bind(':column_name', $candidate);
+            if ($this->db->single()) {
+                $columns[] = $candidate;
+            }
+        }
+
+        return $columns;
+    }
+
+    private function extractApiKeyScopes($apiKeyRecord, $scopeColumns) {
+        $rawScopes = [];
+
+        foreach ($scopeColumns as $column) {
+            if (!property_exists($apiKeyRecord, $column)) {
+                continue;
+            }
+
+            $value = trim((string) ($apiKeyRecord->{$column} ?? ''));
+            if ($value === '') {
+                continue;
+            }
+
+            $decoded = json_decode($value, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                $rawScopes = array_merge($rawScopes, $decoded);
+                continue;
+            }
+
+            $rawScopes = array_merge($rawScopes, preg_split('/[\s,]+/', $value));
+        }
+
+        if (empty($rawScopes)) {
+            $rawScopes = ['blogs:create', 'blogs:update:self'];
+            if (!empty($apiKeyRecord->is_admin)) {
+                $rawScopes[] = 'blogs:update:any';
+                $rawScopes[] = 'blogs:delete:any';
+            }
+        }
+
+        $normalized = [];
+        foreach ($rawScopes as $scope) {
+            $scope = strtolower(trim((string) $scope));
+            if ($scope !== '') {
+                $normalized[] = $scope;
+            }
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    private function assertApiKeyScope($requiredScope) {
+        if (($this->authContext['source'] ?? null) !== 'api_key') {
+            return;
+        }
+
+        $scopes = $this->authContext['api_key_scopes'] ?? [];
+        $requiredScope = strtolower($requiredScope);
+
+        if (in_array('*', $scopes, true) || in_array('blogs:*', $scopes, true) || in_array($requiredScope, $scopes, true)) {
+            return;
+        }
+
+        $this->sendError('API-sleutel mist vereiste scope: ' . $requiredScope, 403);
+    }
+
+    private function auditApiKeyWrite($action, $blogId, $effectiveUserId) {
+        if (($this->authContext['source'] ?? null) !== 'api_key') {
+            return;
+        }
+
+        error_log(sprintf(
+            '[API KEY WRITE] action=%s key_id=%d key_owner_id=%d effective_user_id=%d blog_id=%d',
+            (string) $action,
+            (int) ($this->authContext['api_key_id'] ?? 0),
+            (int) ($this->authContext['api_key_owner_id'] ?? 0),
+            (int) $effectiveUserId,
+            (int) $blogId
+        ));
     }
     
     private function verifyJWT($token) {


### PR DESCRIPTION
Closes #110

## Wijzigingen
- `getCurrentUserFromApiKey()` gebruikt nu `api_keys.user_id` en haalt de gekoppelde user op i.p.v. hardcoded `id=1`.
- Scope/permission-check toegevoegd voor write-acties via API key (`blogs:create`, `blogs:update:*`, `blogs:delete:*`).
- Ondersteuning voor scope metadata via `scope`, `scopes` of `permissions` kolommen als die bestaan.
- Fallback scopes toegevoegd voor legacy keys zonder scopekolom.
- Audit logging toegevoegd voor API-key mutaties met key-id, owner-id, effectieve user-id en blog-id.
- `admin/devteam-state.json` bijgewerkt met de laatste developer-run status.

## Testplan
- [ ] API key met geldige owner kan blogs aanmaken
- [ ] API key zonder benodigde scope krijgt 403
- [ ] API key update/delete van niet-eigen blog vereist `*:any` scope
- [ ] Logs bevatten `[API KEY WRITE]` regels bij create/update/delete
