### PR TITLE
fix(api): fail-safe JSON encoding op /api/blogs

### DIFF
--- a/api/endpoints/blogs.php
+++ b/api/endpoints/blogs.php
@@ -638,21 +638,67 @@ class BlogsAPI {
     }
     
     private function sendResponse($data, $statusCode = 200) {
-        http_response_code($statusCode);
-        echo json_encode([
+        $payload = [
             'success' => true,
             'data' => $data,
             'timestamp' => date('c')
-        ], JSON_UNESCAPED_UNICODE);
+        ];
+
+        $encoded = $this->encodeJsonPayload($payload, '/api/blogs success response');
+
+        if ($encoded === false) {
+            $this->sendEncodingFailureResponse();
+        }
+
+        http_response_code($statusCode);
+        echo $encoded;
         exit();
     }
-    
+
     private function sendError($message, $statusCode = 400) {
+        $payload = api_build_error_response($message, (int) $statusCode);
+        $encoded = $this->encodeJsonPayload($payload, '/api/blogs error response');
+
+        if ($encoded === false) {
+            $this->sendEncodingFailureResponse();
+        }
+
         http_response_code($statusCode);
-        echo json_encode(
-            api_build_error_response($message, (int) $statusCode),
+        echo $encoded;
+        exit();
+    }
+
+    private function encodeJsonPayload($payload, $context) {
+        $options = JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE;
+        $encoded = json_encode($payload, $options);
+
+        if ($encoded !== false) {
+            return $encoded;
+        }
+
+        error_log(sprintf(
+            '[BLOGS API JSON ENCODE ERROR] context=%s error=%s',
+            (string) $context,
+            json_last_error_msg()
+        ));
+
+        return false;
+    }
+
+    private function sendEncodingFailureResponse() {
+        $fallback = json_encode(
+            api_build_error_response('Interne serverfout bij serialiseren van response.', 500),
             JSON_UNESCAPED_UNICODE
         );
+
+        http_response_code(500);
+
+        if ($fallback === false) {
+            echo '{"success":false,"error":"Interne serverfout","code":500}';
+            exit();
+        }
+
+        echo $fallback;
         exit();
     }
 } 


### PR DESCRIPTION
Closes #111

## Wijzigingen
- `sendResponse()` en `sendError()` gaan nu via centrale `encodeJsonPayload()` helper
- `json_encode` gebruikt `JSON_INVALID_UTF8_SUBSTITUTE` om invalide UTF-8 veilig te substitueren
- Bij encode-fout loggen we context + `json_last_error_msg()` via `error_log`
- Fallback pad toegevoegd: consistente 500 JSON error payload als serialisatie toch faalt

## Gewijzigde bestanden
- `api/endpoints/blogs.php` - fail-safe JSON encoding + gecontroleerde 500 fallback

## Test plan
- [ ] `GET /api/blogs` geeft geldige JSON op normale dataset
- [ ] endpoint blijft geldige JSON teruggeven met invalide UTF-8 in contentvelden
- [ ] bij encode-fout verschijnt loggingregel `[BLOGS API JSON ENCODE ERROR]` in server logs
- [ ] health check op `/api/blogs` blijft groen
