### PR TITLE
security(api): redacteer exception-details uit publieke responses

### DIFF
--- a/api/endpoints/auth.php
+++ b/api/endpoints/auth.php
@@ -101,7 +101,7 @@ class AuthAPI {
             ]);
             
         } catch (Exception $e) {
-            $this->sendError('Database fout: ' . $e->getMessage(), 500);
+            $this->sendError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -190,7 +190,7 @@ class AuthAPI {
             }
             
         } catch (Exception $e) {
-            $this->sendError('Database fout: ' . $e->getMessage(), 500);
+            $this->sendError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -314,10 +314,10 @@ class AuthAPI {
         exit();
     }
     
-    private function sendError($message, $statusCode = 400) {
+    private function sendError($message, $statusCode = 400, $debug = null) {
         http_response_code($statusCode);
         echo json_encode(
-            api_build_error_response($message, (int) $statusCode),
+            api_build_error_response($message, (int) $statusCode, $debug),
             JSON_UNESCAPED_UNICODE
         );
         exit();

--- a/api/endpoints/blog-polls.php
+++ b/api/endpoints/blog-polls.php
@@ -67,7 +67,7 @@ class BlogPollsAPI {
             sendApiResponse(['poll' => $poll]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen poll: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -92,7 +92,7 @@ class BlogPollsAPI {
             sendApiResponse(['poll' => $poll]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen poll: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -147,7 +147,7 @@ class BlogPollsAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij aanmaken poll: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -178,7 +178,7 @@ class BlogPollsAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij stemmen: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
 }

--- a/api/endpoints/comments.php
+++ b/api/endpoints/comments.php
@@ -76,7 +76,7 @@ class CommentsAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen comments: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -118,7 +118,7 @@ class CommentsAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij toevoegen comment: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -161,7 +161,7 @@ class CommentsAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij bijwerken comment: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -196,7 +196,7 @@ class CommentsAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij verwijderen comment: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -220,7 +220,7 @@ class CommentsAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij liken comment: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
 }

--- a/api/endpoints/contact.php
+++ b/api/endpoints/contact.php
@@ -69,7 +69,7 @@ class ContactAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij verzenden contactbericht: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
 }

--- a/api/endpoints/forum.php
+++ b/api/endpoints/forum.php
@@ -103,7 +103,7 @@ class ForumAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen topics: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -145,7 +145,7 @@ class ForumAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen topic: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -180,7 +180,7 @@ class ForumAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij aanmaken topic: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -230,7 +230,7 @@ class ForumAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij bijwerken topic: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -265,7 +265,7 @@ class ForumAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij verwijderen topic: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -311,7 +311,7 @@ class ForumAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij toevoegen reply: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -354,7 +354,7 @@ class ForumAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij bijwerken reply: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -389,7 +389,7 @@ class ForumAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij verwijderen reply: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
 }

--- a/api/endpoints/news.php
+++ b/api/endpoints/news.php
@@ -80,7 +80,7 @@ class NewsAPI {
             ]);
             
         } catch (Exception $e) {
-            $this->sendError('Database fout: ' . $e->getMessage(), 500);
+            $this->sendError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -119,7 +119,7 @@ class NewsAPI {
             ]);
             
         } catch (Exception $e) {
-            $this->sendError('Fout bij ophalen statistieken: ' . $e->getMessage(), 500);
+            $this->sendError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -229,7 +229,7 @@ class NewsAPI {
             ]);
             
         } catch (Exception $e) {
-            $this->sendError('Fout bij ophalen recent nieuws: ' . $e->getMessage(), 500);
+            $this->sendError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -326,10 +326,10 @@ class NewsAPI {
         exit();
     }
     
-    private function sendError($message, $statusCode = 400) {
+    private function sendError($message, $statusCode = 400, $debug = null) {
         http_response_code($statusCode);
         echo json_encode(
-            api_build_error_response($message, (int) $statusCode),
+            api_build_error_response($message, (int) $statusCode, $debug),
             JSON_UNESCAPED_UNICODE
         );
         exit();

--- a/api/endpoints/parties.php
+++ b/api/endpoints/parties.php
@@ -81,7 +81,7 @@ class PartiesAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen partijen: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -109,7 +109,7 @@ class PartiesAPI {
             sendApiResponse(['party' => $party]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen partij: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -136,7 +136,7 @@ class PartiesAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen polling data: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -163,7 +163,7 @@ class PartiesAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen standpunten: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -215,7 +215,7 @@ class PartiesAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij aanmaken partij: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -265,7 +265,7 @@ class PartiesAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij bijwerken partij: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -283,7 +283,7 @@ class PartiesAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij verwijderen partij: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     

--- a/api/endpoints/presidenten.php
+++ b/api/endpoints/presidenten.php
@@ -68,7 +68,7 @@ class PresidentenAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen presidenten: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -91,7 +91,7 @@ class PresidentenAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen president: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -108,7 +108,7 @@ class PresidentenAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij aanmaken president: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -214,7 +214,7 @@ class PresidentenAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij bijwerken president: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -234,7 +234,7 @@ class PresidentenAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij verwijderen president: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     

--- a/api/endpoints/stats.php
+++ b/api/endpoints/stats.php
@@ -70,7 +70,7 @@ class StatsAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen statistieken: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -107,7 +107,7 @@ class StatsAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen trending content: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -168,7 +168,7 @@ class StatsAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen recente activiteit: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
 }

--- a/api/endpoints/stemmentracker.php
+++ b/api/endpoints/stemmentracker.php
@@ -124,7 +124,7 @@ class StemmentrackerAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen moties: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -155,7 +155,7 @@ class StemmentrackerAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen motie: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -174,7 +174,7 @@ class StemmentrackerAPI {
             sendApiResponse(['votes' => $votes]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen votes: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -194,7 +194,7 @@ class StemmentrackerAPI {
             sendApiResponse(['votes' => $votes]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen party votes: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -240,7 +240,7 @@ class StemmentrackerAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij aanmaken motie: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -282,7 +282,7 @@ class StemmentrackerAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij bijwerken motie: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -300,7 +300,7 @@ class StemmentrackerAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij verwijderen motie: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -332,7 +332,7 @@ class StemmentrackerAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij toevoegen vote: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     

--- a/api/endpoints/themas.php
+++ b/api/endpoints/themas.php
@@ -59,7 +59,7 @@ class ThemasAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen themas: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -90,7 +90,7 @@ class ThemasAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen thema: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -122,7 +122,7 @@ class ThemasAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij aanmaken thema: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -163,7 +163,7 @@ class ThemasAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij bijwerken thema: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -181,7 +181,7 @@ class ThemasAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij verwijderen thema: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     

--- a/api/endpoints/user.php
+++ b/api/endpoints/user.php
@@ -86,7 +86,7 @@ class UserAPI {
             ]);
             
         } catch (Exception $e) {
-            $this->sendError('Database fout: ' . $e->getMessage(), 500);
+            $this->sendError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -165,7 +165,7 @@ class UserAPI {
             $this->sendResponse(['stats' => $stats]);
             
         } catch (Exception $e) {
-            $this->sendError('Database fout: ' . $e->getMessage(), 500);
+            $this->sendError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -229,7 +229,7 @@ class UserAPI {
             ]);
             
         } catch (Exception $e) {
-            $this->sendError('Database fout: ' . $e->getMessage(), 500);
+            $this->sendError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -319,7 +319,7 @@ class UserAPI {
             }
             
         } catch (Exception $e) {
-            $this->sendError('Database fout: ' . $e->getMessage(), 500);
+            $this->sendError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -376,7 +376,7 @@ class UserAPI {
             }
             
         } catch (Exception $e) {
-            $this->sendError('Database fout: ' . $e->getMessage(), 500);
+            $this->sendError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -457,10 +457,10 @@ class UserAPI {
         exit();
     }
     
-    private function sendError($message, $statusCode = 400) {
+    private function sendError($message, $statusCode = 400, $debug = null) {
         http_response_code($statusCode);
         echo json_encode(
-            api_build_error_response($message, (int) $statusCode),
+            api_build_error_response($message, (int) $statusCode, $debug),
             JSON_UNESCAPED_UNICODE
         );
         exit();

--- a/api/endpoints/verkiezingen-nl.php
+++ b/api/endpoints/verkiezingen-nl.php
@@ -63,7 +63,7 @@ class VerkiezingenNLAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen verkiezingen: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -83,7 +83,7 @@ class VerkiezingenNLAPI {
             sendApiResponse(['verkiezing' => $verkiezing]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen verkiezing: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -143,7 +143,7 @@ class VerkiezingenNLAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij aanmaken verkiezing: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -193,7 +193,7 @@ class VerkiezingenNLAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij bijwerken verkiezing: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -211,7 +211,7 @@ class VerkiezingenNLAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij verwijderen verkiezing: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     

--- a/api/endpoints/verkiezingen-usa.php
+++ b/api/endpoints/verkiezingen-usa.php
@@ -63,7 +63,7 @@ class VerkiezingenUSAAPI {
             ]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen verkiezingen: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -83,7 +83,7 @@ class VerkiezingenUSAAPI {
             sendApiResponse(['verkiezing' => $verkiezing]);
             
         } catch (Exception $e) {
-            sendApiError('Fout bij ophalen verkiezing: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -132,7 +132,7 @@ class VerkiezingenUSAAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij aanmaken verkiezing: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -176,7 +176,7 @@ class VerkiezingenUSAAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij bijwerken verkiezing: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     
@@ -194,7 +194,7 @@ class VerkiezingenUSAAPI {
             }
             
         } catch (Exception $e) {
-            sendApiError('Fout bij verwijderen verkiezing: ' . $e->getMessage(), 500);
+            sendApiError('Interne serverfout', 500, ['exception' => $e->getMessage()]);
         }
     }
     

--- a/api/index.php
+++ b/api/index.php
@@ -143,7 +143,10 @@ try {
         $testDb = new Database();
         debug_log("Database verbinding succesvol");
     } catch (Exception $e) {
-        sendApiError("Database verbinding mislukt: " . $e->getMessage(), 500);
+        sendApiError("Interne serverfout", 500, [
+            "context" => "database_connect",
+            "exception" => $e->getMessage()
+        ]);
     }
     
     // Andere belangrijke classes laden
@@ -173,7 +176,9 @@ try {
     }
     
 } catch (Exception $e) {
-    sendApiError("Include fout: " . $e->getMessage(), 500, [
+    sendApiError("Interne serverfout", 500, [
+        "context" => "include_bootstrap",
+        "exception" => $e->getMessage(),
         'file' => $e->getFile(),
         'line' => $e->getLine()
     ]);
@@ -289,7 +294,9 @@ class APIRouter {
             }
             
         } catch (Exception $e) {
-            sendApiError('Router fout: ' . $e->getMessage(), 500, [
+            sendApiError('Interne serverfout', 500, [
+                'context' => 'router_dispatch',
+                'exception' => $e->getMessage(),
                 'file' => $e->getFile(),
                 'line' => $e->getLine(),
                 'trace' => API_DEBUG ? $e->getTraceAsString() : null
@@ -582,7 +589,9 @@ try {
     $router = new APIRouter();
     $router->route();
 } catch (Exception $e) {
-    sendApiError('Fatale fout: ' . $e->getMessage(), 500, [
+    sendApiError('Interne serverfout', 500, [
+        'context' => 'api_index_catch',
+        'exception' => $e->getMessage(),
         'file' => $e->getFile(),
         'line' => $e->getLine(),
         'trace' => API_DEBUG ? $e->getTraceAsString() : null


### PR DESCRIPTION
Closes #118

## Wijzigingen
- Alle API endpoint catch-blokken met directe `$e->getMessage()` output vervangen door generieke 500-response (`Interne serverfout`).
- Exception-details gaan nu via debug-context naar de centrale API error helper, zodat ze alleen server-side gelogd worden met `request_id`.
- `sendError()` in class-based endpoints (`auth`, `user`, `news`) uitgebreid met optionele debug-context voor consistente logging zonder client-leak.
- Bootstrapping/router catch in `api/index.php` idem gehardend naar generieke output + context logging.

## Gewijzigde bestanden
- `api/index.php`
- `api/endpoints/auth.php`
- `api/endpoints/user.php`
- `api/endpoints/news.php`
- `api/endpoints/{parties,presidenten,forum,themas,verkiezingen-nl,verkiezingen-usa,comments,contact,stats,stemmentracker,blog-polls}.php`

## Test plan
- [ ] Trigger een geforceerde DB-exception op `POST /api/auth/login`: response bevat geen SQL/exception-tekst, wel `request_id`.
- [ ] Trigger een exception op content endpoint (bijv. `/api/parties`): zelfde gedrag.
- [ ] Controleer server logs: exception details aanwezig met `request_id` correlatie.

## Opmerking
`php -l` kon ik lokaal in deze runner niet uitvoeren omdat `php` binary ontbreekt (`php: command not found`).
