### PR TITLE
refactor(js): splits partijen landing-script uit controller

### DIFF
--- a/controllers/partijen.php
+++ b/controllers/partijen.php
@@ -38,132 +38,6 @@ include_once BASE_PATH . '/views/templates/header.php';
     <script>window.__PP_PARTIES__ = <?php echo $parties_json; ?>;</script>
     <?php include BASE_PATH . '/views/partijen/partials/hero-section.php'; ?>
     
-    <!-- Enhanced Scripts for Political Dashboard -->
-    <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        // Smooth scrolling for anchor links
-        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-            anchor.addEventListener('click', function (e) {
-                e.preventDefault();
-                const target = document.querySelector(this.getAttribute('href'));
-                if (target) {
-                    target.scrollIntoView({
-                        behavior: 'smooth',
-                        block: 'start'
-                    });
-                }
-            });
-        });
-        
-        // Typing Animation
-        const typingElement = document.getElementById('typing-text');
-        const texts = [
-            'Waar democratie vorm krijgt...',
-            'Waar standpunten botsen...',
-            'Waar leiders inspireren...',
-            'Waar jouw stem telt...'
-        ];
-        
-        let textIndex = 0;
-        let charIndex = 0;
-        let isDeleting = false;
-        let typingSpeed = 100;
-        
-        function typeText() {
-            const currentText = texts[textIndex];
-            
-            if (isDeleting) {
-                typingElement.textContent = currentText.substring(0, charIndex - 1);
-                charIndex--;
-                typingSpeed = 50;
-            } else {
-                typingElement.textContent = currentText.substring(0, charIndex + 1);
-                charIndex++;
-                typingSpeed = 100;
-            }
-            
-            if (!isDeleting && charIndex === currentText.length) {
-                typingSpeed = 2000;
-                isDeleting = true;
-            } else if (isDeleting && charIndex === 0) {
-                isDeleting = false;
-                textIndex = (textIndex + 1) % texts.length;
-                typingSpeed = 500;
-            }
-            
-            setTimeout(typeText, typingSpeed);
-        }
-        
-        typeText();
-        
-        // Leaders Carousel
-        const leaderCards = document.querySelectorAll('.leader-card');
-        const carouselDots = document.querySelectorAll('.carousel-dot');
-        let currentLeader = 0;
-        
-        function showLeader(index) {
-            leaderCards.forEach((card, i) => {
-                if (i === index) {
-                    card.classList.remove('hidden');
-                    card.classList.add('active');
-                } else {
-                    card.classList.add('hidden');
-                    card.classList.remove('active');
-                }
-            });
-            
-            carouselDots.forEach((dot, i) => {
-                if (i === index) {
-                    dot.classList.remove('bg-white/30');
-                    dot.classList.add('bg-white');
-                } else {
-                    dot.classList.add('bg-white/30');
-                    dot.classList.remove('bg-white');
-                }
-            });
-        }
-        
-        // Auto-rotate carousel
-        setInterval(() => {
-            currentLeader = (currentLeader + 1) % leaderCards.length;
-            showLeader(currentLeader);
-        }, 4000);
-        
-        // Manual carousel control
-        carouselDots.forEach((dot, index) => {
-            dot.addEventListener('click', () => {
-                currentLeader = index;
-                showLeader(currentLeader);
-            });
-        });
-        
-        // Seat Distribution Animation
-        const seatBars = document.querySelectorAll('#seat-distribution .h-1');
-        
-        // Animate progress bars on load
-        setTimeout(() => {
-            seatBars.forEach((bar, index) => {
-                bar.style.transform = 'scaleX(0)';
-                bar.style.transformOrigin = 'left';
-                setTimeout(() => {
-                    bar.style.transform = 'scaleX(1)';
-                }, index * 200);
-            });
-        }, 1000);
-        
-        // Subtle pulse animation for the bars
-        setInterval(() => {
-            seatBars.forEach((bar, index) => {
-                setTimeout(() => {
-                    bar.style.transform = 'scaleX(1.02)';
-                    setTimeout(() => {
-                        bar.style.transform = 'scaleX(1)';
-                    }, 200);
-                }, index * 100);
-            });
-        }, 8000); // Every 8 seconds
-    });
-    </script>
 
     <!-- AI Analyse Modal -->
     <div id="ai-modal" class="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 hidden opacity-0 transition-opacity duration-300">
@@ -1509,6 +1383,7 @@ window.PP_CONFIG = Object.freeze({
 });
 </script>
 <script src="<?php echo URLROOT; ?>/js/partijen-page.js" defer></script>
+<script src="<?php echo URLROOT; ?>/js/partijen-landing-effects.js" defer></script>
 
 <style>
 /* Smooth scrolling for the entire page */

--- a/js/partijen-landing-effects.js
+++ b/js/partijen-landing-effects.js
@@ -1,0 +1,104 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+        anchor.addEventListener('click', (event) => {
+            event.preventDefault();
+            const target = document.querySelector(anchor.getAttribute('href'));
+            if (target) {
+                target.scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'start'
+                });
+            }
+        });
+    });
+
+    const typingElement = document.getElementById('typing-text');
+    if (typingElement) {
+        const texts = [
+            'Waar democratie vorm krijgt...',
+            'Waar standpunten botsen...',
+            'Waar leiders inspireren...',
+            'Waar jouw stem telt...'
+        ];
+
+        let textIndex = 0;
+        let charIndex = 0;
+        let isDeleting = false;
+
+        const typeText = () => {
+            const currentText = texts[textIndex];
+            const nextLength = isDeleting ? charIndex - 1 : charIndex + 1;
+            typingElement.textContent = currentText.substring(0, nextLength);
+            charIndex = nextLength;
+
+            let typingSpeed = isDeleting ? 50 : 100;
+
+            if (!isDeleting && charIndex === currentText.length) {
+                typingSpeed = 2000;
+                isDeleting = true;
+            } else if (isDeleting && charIndex === 0) {
+                isDeleting = false;
+                textIndex = (textIndex + 1) % texts.length;
+                typingSpeed = 500;
+            }
+
+            window.setTimeout(typeText, typingSpeed);
+        };
+
+        typeText();
+    }
+
+    const leaderCards = document.querySelectorAll('.leader-card');
+    const carouselDots = document.querySelectorAll('.carousel-dot');
+    if (leaderCards.length && carouselDots.length) {
+        let currentLeader = 0;
+
+        const showLeader = (index) => {
+            leaderCards.forEach((card, i) => {
+                card.classList.toggle('hidden', i !== index);
+                card.classList.toggle('active', i === index);
+            });
+
+            carouselDots.forEach((dot, i) => {
+                dot.classList.toggle('bg-white/30', i !== index);
+                dot.classList.toggle('bg-white', i === index);
+            });
+        };
+
+        window.setInterval(() => {
+            currentLeader = (currentLeader + 1) % leaderCards.length;
+            showLeader(currentLeader);
+        }, 4000);
+
+        carouselDots.forEach((dot, index) => {
+            dot.addEventListener('click', () => {
+                currentLeader = index;
+                showLeader(currentLeader);
+            });
+        });
+    }
+
+    const seatBars = document.querySelectorAll('#seat-distribution .h-1');
+    if (seatBars.length) {
+        window.setTimeout(() => {
+            seatBars.forEach((bar, index) => {
+                bar.style.transform = 'scaleX(0)';
+                bar.style.transformOrigin = 'left';
+                window.setTimeout(() => {
+                    bar.style.transform = 'scaleX(1)';
+                }, index * 200);
+            });
+        }, 1000);
+
+        window.setInterval(() => {
+            seatBars.forEach((bar, index) => {
+                window.setTimeout(() => {
+                    bar.style.transform = 'scaleX(1.02)';
+                    window.setTimeout(() => {
+                        bar.style.transform = 'scaleX(1)';
+                    }, 200);
+                }, index * 100);
+            });
+        }, 8000);
+    }
+});


### PR DESCRIPTION
Closes #87

## Wijzigingen
- inline DOMContentLoaded-script uit `controllers/partijen.php` gehaald
- nieuw bestand toegevoegd: `js/partijen-landing-effects.js`
- script nu deferred geladen vanuit de controller
- extra guards toegevoegd zodat animaties alleen draaien als de benodigde DOM-elementen bestaan

## Waarom
- controller wordt kleiner en beter onderhoudbaar
- frontend gedrag blijft gelijk, maar JS staat nu op de juiste plek

## Test plan
- open `/partijen` en controleer smooth scroll op ankerlinks
- controleer typing effect in hero (`#typing-text`)
- controleer leader carousel auto-rotate + dots
- controleer seat-distribution animatie
