### PR TITLE
perf(db): add missing indexes for news_articles hot queries

### DIFF
--- a/database/README_NIEUWS_MIGRATIE.md
+++ b/database/README_NIEUWS_MIGRATIE.md
@@ -20,10 +20,13 @@ CREATE TABLE IF NOT EXISTS news_articles (
     published_at TIMESTAMP NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE INDEX uq_news_articles_url (url(255)),
     INDEX idx_source (source),
     INDEX idx_bias (bias),
     INDEX idx_orientation (orientation),
-    INDEX idx_published_at (published_at)
+    INDEX idx_published_at (published_at),
+    INDEX idx_source_published_at (source, published_at),
+    INDEX idx_orientation_published_at (orientation, published_at)
 );
 ```
 
@@ -45,6 +48,7 @@ CREATE TABLE IF NOT EXISTS news_articles (
 ### Migratie Bestanden
 
 - `database/migrations/create_news_articles_table.sql` - SQL script voor tabel aanmaak
+- `database/migrations/add_news_articles_hot_query_indexes.sql` - idempotente index-migratie voor hot queries
 - `scripts/populate_news_database.php` - Script om initiële data in te laden
 
 ### Model en Controller

--- a/database/migrations/add_news_articles_hot_query_indexes.sql
+++ b/database/migrations/add_news_articles_hot_query_indexes.sql
@@ -1,0 +1,13 @@
+-- Performance en dedupe indexes voor news_articles hot queries
+-- Draai dit script veilig meerdere keren (idempotent via IF NOT EXISTS).
+
+-- Houd alleen de oudste record per URL, zodat UNIQUE index kan worden toegevoegd.
+DELETE n1
+FROM news_articles n1
+INNER JOIN news_articles n2 ON n1.url = n2.url
+WHERE n1.id > n2.id;
+
+ALTER TABLE news_articles
+    ADD UNIQUE INDEX IF NOT EXISTS uq_news_articles_url (url(255)),
+    ADD INDEX IF NOT EXISTS idx_source_published_at (source, published_at),
+    ADD INDEX IF NOT EXISTS idx_orientation_published_at (orientation, published_at);

--- a/database/migrations/create_news_articles_table.sql
+++ b/database/migrations/create_news_articles_table.sql
@@ -10,8 +10,11 @@ CREATE TABLE IF NOT EXISTS news_articles (
     published_at TIMESTAMP NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE INDEX uq_news_articles_url (url(255)),
     INDEX idx_source (source),
     INDEX idx_bias (bias),
     INDEX idx_orientation (orientation),
-    INDEX idx_published_at (published_at)
+    INDEX idx_published_at (published_at),
+    INDEX idx_source_published_at (source, published_at),
+    INDEX idx_orientation_published_at (orientation, published_at)
 ); 


### PR DESCRIPTION
Closes #135

## Wijzigingen
- `create_news_articles_table.sql` uitgebreid met:
  - `uq_news_articles_url (url(255))`
  - `idx_source_published_at (source, published_at)`
  - `idx_orientation_published_at (orientation, published_at)`
- Nieuwe idempotente migratie toegevoegd: `add_news_articles_hot_query_indexes.sql`
  - dedupe stap op `url` voor veilige UNIQUE-index toevoeging
  - `ALTER TABLE ... ADD ... IF NOT EXISTS` voor herhaalbare runs
- Documentatie bijgewerkt in `database/README_NIEUWS_MIGRATIE.md`

## Test plan
- [x] SQL migratiebestanden gecontroleerd op syntax/consistente indexnamen
- [x] Idempotent patroon gebruikt (`IF NOT EXISTS`) voor veilige reruns
- [ ] Op staging/prod draaien en `EXPLAIN` valideren op:
  - `WHERE url = ?`
  - `WHERE source = ? AND published_at >= ...`
  - `WHERE orientation = ? AND published_at >= ...`
