### PR TITLE
security(profile): voeg CSRF-bescherming toe op profile edit

### DIFF
--- a/controllers/profile/edit.php
+++ b/controllers/profile/edit.php
@@ -3,10 +3,12 @@ require_once __DIR__ . '/../../includes/config.php';
 require_once __DIR__ . '/../../includes/auth_check.php';
 require_once __DIR__ . '/../../includes/Database.php';
 require_once __DIR__ . '/../../includes/helpers.php';
+require_once __DIR__ . '/../../includes/auth_csrf.php';
 
 $user_id = $_SESSION['user_id'];
 $error = '';
 $success = '';
+$csrf_token = auth_ensure_csrf_token();
 
 // Maak database verbinding
 $db = new Database();
@@ -14,6 +16,10 @@ $pdo = $db->getConnection();
 
 // Als het formulier is verzonden
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!auth_require_csrf_token_from_post()) {
+        $error = 'Sessie verlopen of ongeldig formulierverzoek. Probeer het opnieuw.';
+    }
+
     $username = trim($_POST['username']);
     $email = trim($_POST['email']);
     $bio = isset($_POST['bio']) ? trim($_POST['bio']) : '';
@@ -79,7 +85,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $notify_site_likes = isset($_POST['notify_site_likes']) ? 1 : 0;
 
     // Validatie
-    if (empty($username) || empty($email)) {
+    if (!empty($error)) {
+        // Ongeldige CSRF-token: blokkeer profielmutatie.
+    } elseif (empty($username) || empty($email)) {
         $error = "Gebruikersnaam en e-mail zijn verplicht.";
     } elseif ($new_password !== $confirm_password) {
         $error = "Wachtwoorden komen niet overeen.";

--- a/views/profile/edit.php
+++ b/views/profile/edit.php
@@ -53,6 +53,7 @@
                 </div>
                 
                 <form method="POST" class="space-y-6" id="profile-form" enctype="multipart/form-data">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf_token, ENT_QUOTES, 'UTF-8'); ?>">
                     <!-- Tab: Account Gegevens -->
                     <div class="tab-content" id="content-account">
                         <div class="grid gap-6 md:grid-cols-2">


### PR DESCRIPTION
Closes #153

## Wijzigingen
- controllers/profile/edit.php laadt nu includes/auth_csrf.php en genereert een token via auth_ensure_csrf_token()
- POST-flow valideert nu direct met auth_require_csrf_token_from_post() en blokkeert mutaties bij ontbrekende/ongeldige token
- views/profile/edit.php bevat nu een hidden csrf_token veld in het profiel-formulier

## Gewijzigde bestanden
- controllers/profile/edit.php - CSRF bootstrap + POST validatie op profile mutaties
- views/profile/edit.php - hidden token field

## Testplan
- [ ] Ingelogd profiel edit met geldige token werkt normaal
- [ ] POST naar profile/edit zonder token geeft HTTP 403 en voert geen mutatie uit
- [ ] POST met fout token geeft HTTP 403 en voert geen mutatie uit
