### PR TITLE
fix(peilingen): vervang hardcoded zetels door dynamische DB-query + update naar maart 2026

### DIFF
--- a/scripts/update_peilingen.php
+++ b/scripts/update_peilingen.php
@@ -6,23 +6,23 @@ echo "=========================================\n";
 echo "   PolitiekPraat Peiling Update Script   \n";
 echo "=========================================\n\n";
 
-// Nieuwe peiling data gebaseerd op Ipsos I&O d.d. 25-10-2025
+// Nieuwe peiling data gebaseerd op Ipsos I&O d.d. 09-03-2026
 $new_polls = [
-    'pvv'      => 26,
-    'gl-pvda'  => 23,
-    'd66'      => 22,
-    'cda'      => 20,
-    'vvd'      => 16,
-    'ja21'     => 12,
-    'fvd'      => 5,
-    'pvdd'     => 4,
-    'bbb'      => 4,
+    'gl-pvda'  => 25,
+    'd66'      => 24,
+    'vvd'      => 21,
+    'pvv'      => 19,
+    'ja21'     => 14,
+    'cda'      => 15,
+    'fvd'      => 10,
     'sp'       => 4,
+    'volt'     => 4,
+    'pvdd'     => 3,
     'denk'     => 3,
-    'volt'     => 3,
     'sgp'      => 3,
     'cu'       => 3,
-    '50plus'   => 2,
+    'bbb'      => 1,
+    '50plus'   => 1,
     'nsc'      => 0
 ];
 
@@ -47,7 +47,7 @@ try {
             // Bereken het nieuwe percentage (totaal 150 zetels in de Tweede Kamer)
             $new_percentage = round(($new_seats / 150) * 100, 1);
 
-            // Bereken het verschil met de TK2023 uitslag (current_seats)
+            // Bereken het verschil met de TK2025 uitslag (current_seats)
             $change = $new_seats - $party->current_seats;
 
             // Creëer de nieuwe JSON data voor de 'polling' kolom
@@ -75,7 +75,7 @@ try {
     }
 
     echo "\n\n================= KLAAR =================\n";
-    echo "Update voltooid.\n";
+    echo "Update voltooid. Bron: Ipsos I&O zetelpeiling 9 maart 2026.\n";
     echo "- " . $updated_count . " partijen succesvol geüpdatet.\n";
     echo "- " . $not_found_count . " partijen niet gevonden en overgeslagen.\n";
     echo "=========================================\n";

--- a/views/partijen/partials/hero-section.php
+++ b/views/partijen/partials/hero-section.php
@@ -162,7 +162,7 @@
                                 <!-- Zetel Verdeling -->
                                 <div class="bg-white/5 backdrop-blur-sm rounded-2xl p-4 border border-white/10">
                                     <div class="flex items-center justify-between mb-4">
-                                        <h4 class="text-white font-bold text-sm">Grootste Partijen</h4>
+                                        <h4 class="text-white font-bold text-sm">Grootste Partijen (Peilingen)</h4>
                                         <div class="flex items-center space-x-2">
                                             <div class="w-2 h-2 bg-blue-400 rounded-full animate-pulse"></div>
                                             <span class="text-blue-400 text-xs font-medium">ACTUEEL</span>
@@ -170,68 +170,35 @@
                                     </div>
                                     
                                     <div class="space-y-3" id="seat-distribution">
-                                        <!-- PVV -->
+                                        <?php
+                                        // Sort by polling seats descending, take top 4
+                                        $sortedForHero = $parties;
+                                        uasort($sortedForHero, function($a, $b) {
+                                            return ($b['polling']['seats'] ?? 0) - ($a['polling']['seats'] ?? 0);
+                                        });
+                                        $top4 = array_slice($sortedForHero, 0, 4, true);
+                                        $maxHeroSeats = max(array_map(function($p) { return $p['polling']['seats'] ?? 0; }, $top4)) ?: 1;
+                                        foreach ($top4 as $heroKey => $heroParty):
+                                            $heroSeats = $heroParty['polling']['seats'] ?? 0;
+                                            $heroWidth = round(($heroSeats / $maxHeroSeats) * 100, 1);
+                                            $heroColor = getPartyColor($heroKey);
+                                        ?>
                                         <div class="flex items-center space-x-3">
-                                            <div class="w-2 h-2 rounded-full" style="background-color: #1e3a8a;"></div>
+                                            <div class="w-2 h-2 rounded-full" style="background-color: <?php echo $heroColor; ?>;"></div>
                                             <div class="flex-1">
                                                 <div class="flex justify-between items-center mb-1">
-                                                    <span class="text-white text-xs font-medium">PVV</span>
-                                                    <span class="text-blue-200 text-xs">37 zetels</span>
+                                                    <span class="text-white text-xs font-medium"><?php echo htmlspecialchars($heroKey); ?></span>
+                                                    <span class="text-blue-200 text-xs"><?php echo $heroSeats; ?> zetels</span>
                                                 </div>
                                                 <div class="w-full bg-white/10 rounded-full h-1">
                                                     <div class="h-1 rounded-full transition-all duration-1000" 
-                                                         style="width: 24.7%; background-color: #1e3a8a;"></div>
+                                                         style="width: <?php echo $heroWidth; ?>%; background-color: <?php echo $heroColor; ?>;"></div>
                                                 </div>
                                             </div>
                                         </div>
-                                        
-                                        <!-- VVD -->
-                                        <div class="flex items-center space-x-3">
-                                            <div class="w-2 h-2 rounded-full" style="background-color: #1e40af;"></div>
-                                            <div class="flex-1">
-                                                <div class="flex justify-between items-center mb-1">
-                                                    <span class="text-white text-xs font-medium">VVD</span>
-                                                    <span class="text-blue-200 text-xs">24 zetels</span>
-                                                </div>
-                                                <div class="w-full bg-white/10 rounded-full h-1">
-                                                    <div class="h-1 rounded-full transition-all duration-1000" 
-                                                         style="width: 16%; background-color: #1e40af;"></div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        
-                                        <!-- GL-PvdA -->
-                                        <div class="flex items-center space-x-3">
-                                            <div class="w-2 h-2 rounded-full" style="background-color: #059669;"></div>
-                                            <div class="flex-1">
-                                                <div class="flex justify-between items-center mb-1">
-                                                    <span class="text-white text-xs font-medium">GL-PvdA</span>
-                                                    <span class="text-blue-200 text-xs">25 zetels</span>
-                                                </div>
-                                                <div class="w-full bg-white/10 rounded-full h-1">
-                                                    <div class="h-1 rounded-full transition-all duration-1000" 
-                                                         style="width: 16.7%; background-color: #059669;"></div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        
-                                        <!-- NSC -->
-                                        <div class="flex items-center space-x-3">
-                                            <div class="w-2 h-2 rounded-full" style="background-color: #7c3aed;"></div>
-                                            <div class="flex-1">
-                                                <div class="flex justify-between items-center mb-1">
-                                                    <span class="text-white text-xs font-medium">NSC</span>
-                                                    <span class="text-blue-200 text-xs">20 zetels</span>
-                                                </div>
-                                                <div class="w-full bg-white/10 rounded-full h-1">
-                                                    <div class="h-1 rounded-full transition-all duration-1000" 
-                                                         style="width: 13.3%; background-color: #7c3aed;"></div>
-                                                </div>
-                                            </div>
-                                        </div>
+                                        <?php endforeach; ?>
                                     </div>
                                 </div>
-                                
                                 <!-- Footer -->
                                 <div class="pt-6 border-t border-white/10">
                                     <div class="flex items-center justify-center space-x-3">


### PR DESCRIPTION
## Wijzigingen

### hero-section.php
De 'Grootste Partijen' widget toonde hardcoded TK2023 data (PVV 37, VVD 24, GL-PvdA 25, NSC 20).
Nu wordt dynamisch PHP gebruikt om top-4 partijen op basis van `polling->seats` uit de DB te laden.
Kleur via `getPartyColor()`, breedte-percentage berekend t.o.v. de max van de top-4.

### update_peilingen.php
Bijgewerkt naar **Ipsos I&O zetelpeiling 9 maart 2026**:
- GL-PvdA: 25 zetels
- D66: 24 zetels
- VVD: 21 zetels
- PVV: 19 zetels
- CDA: 15 zetels
- JA21: 14 zetels
- FvD: 10 zetels
- BBB: 1 zetel
- NSC: 0 zetels

## Na merge
Script uitvoeren op VPS: `php scripts/update_peilingen.php`