### PR TITLE
Fix P0: unsubscribe routing, remove prod debug logging, and metadata cleanups

### DIFF
--- a/controllers/nieuws.php
+++ b/controllers/nieuws.php
@@ -90,13 +90,15 @@ if (empty($latest_news)) {
 // Haal statistieken op via NewsModel
 $stats = $newsModel->getNewsStats();
 
-// Log aantallen artikelen
-error_log("Aantal totale artikelen: " . $stats['total_articles']);
-error_log("Aantal progressieve artikelen: " . $stats['progressive_count']);
-error_log("Aantal conservatieve artikelen: " . $stats['conservative_count']);
-error_log("Huidige pagina: $newsCurrentPage van $totalPages");
-error_log("Aantal artikelen op huidige pagina: " . count($latest_news));
-error_log("TotalArticles voor paginering: " . $totalArticles);
+// Log aantallen artikelen alleen tijdens expliciete debug-sessies.
+if (APP_DEBUG && isset($_GET['debug'])) {
+    error_log("Aantal totale artikelen: " . $stats['total_articles']);
+    error_log("Aantal progressieve artikelen: " . $stats['progressive_count']);
+    error_log("Aantal conservatieve artikelen: " . $stats['conservative_count']);
+    error_log("Huidige pagina: $newsCurrentPage van $totalPages");
+    error_log("Aantal artikelen op huidige pagina: " . count($latest_news));
+    error_log("TotalArticles voor paginering: " . $totalArticles);
+}
 
 // Leeg de cache als er een parameter is meegegeven (behouden voor compatibiliteit)
 if (isset($_GET['clear_cache']) && $_GET['clear_cache'] === '1') {

--- a/index.php
+++ b/index.php
@@ -102,7 +102,10 @@ $router->add('nieuws', 'controllers/nieuws.php');
 $router->add('profile', 'controllers/profile/index.php');
 $router->add('profile/edit', 'controllers/profile/edit.php');
 $router->add('newsletter/subscribe', 'controllers/newsletter.php');
-$router->add('newsletter/unsubscribe', 'controllers/newsletter.php?action=unsubscribe');
+$router->add('newsletter/unsubscribe', function() {
+    $_GET['action'] = 'unsubscribe';
+    require_once 'controllers/newsletter.php';
+});
 $router->add('partijmeter', 'controllers/partijmeter.php');
 $router->add('resultaten/([a-zA-Z0-9]+)', function($shareId) {
     $_GET['id'] = $shareId;

--- a/views/blogs/update_likes.php
+++ b/views/blogs/update_likes.php
@@ -6,10 +6,6 @@ require_once '../../includes/config.php';
 require_once '../../includes/Database.php';
 require_once '../../includes/auth_csrf.php';
 
-// Debug logging
-error_log("Like endpoint hit - Method: " . $_SERVER['REQUEST_METHOD']);
-error_log("Headers: " . print_r(getallheaders(), true));
-
 // Check if this is an AJAX request or regular POST
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!auth_require_csrf_token_from_post()) {
@@ -22,17 +18,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     try {
-        $sanitizedPost = $_POST;
-        unset($sanitizedPost['csrf_token']);
-        error_log("POST data: " . print_r($sanitizedPost, true));
         if (!isset($_POST['slug']) || !isset($_POST['action'])) {
             throw new Exception('Ontbrekende parameters - slug: ' . (isset($_POST['slug']) ? 'aanwezig' : 'ontbreekt') . ', action: ' . (isset($_POST['action']) ? 'aanwezig' : 'ontbreekt'));
         }
         
         $slug = trim($_POST['slug']);
         $action = trim($_POST['action']); // 'like' or 'unlike'
-        
-        error_log("Processing like action: $action for slug: $slug");
         
         if (!in_array($action, ['like', 'unlike'])) {
             throw new Exception('Ongeldige actie: ' . $action);
@@ -49,8 +40,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             throw new Exception('Blog niet gevonden voor slug: ' . $slug);
         }
         
-        error_log("Current likes: " . $currentLikes->likes);
-        
         // Update likes based on action
         $newLikes = $currentLikes->likes;
         if ($action === 'like') {
@@ -58,8 +47,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } else {
             $newLikes = max(0, $newLikes - 1);
         }
-        
-        error_log("New likes: " . $newLikes);
         
         // Update in database
         $db->query("UPDATE blogs SET likes = :likes WHERE slug = :slug");
@@ -71,17 +58,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             throw new Exception('Database update mislukt');
         }
         
-        error_log("Like action successful");
-        
         echo json_encode([
             'success' => true,
             'likes' => $newLikes,
-            'action' => $action,
-            'debug' => [
-                'slug' => $slug,
-                'old_likes' => $currentLikes->likes,
-                'new_likes' => $newLikes
-            ]
         ]);
         
     } catch (Exception $e) {
@@ -89,11 +68,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         http_response_code(400);
         echo json_encode([
             'success' => false,
-            'error' => $e->getMessage(),
-            'debug' => [
-                'slug' => isset($_POST['slug']) ? $_POST['slug'] : 'not set',
-                'action' => isset($_POST['action']) ? $_POST['action'] : 'not set'
-            ]
+            'error' => 'De like kon niet worden verwerkt'
         ]);
     }
     
@@ -102,7 +77,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Not a POST request, might be direct access - show error
     echo json_encode([
         'success' => false,
-        'error' => 'Only POST requests allowed'
+        'error' => 'Alleen POST-verzoeken zijn toegestaan'
     ]);
     exit;
 }

--- a/views/templates/header.php
+++ b/views/templates/header.php
@@ -222,7 +222,7 @@ $defaultPageTitles = [
     'home' => 'PolitiekPraat - Politiek nieuws, blogs en stemhulp',
     'blogs' => 'Politieke blogs en opinie - PolitiekPraat',
     'nieuws' => 'Laatste politieke nieuws uit Nederland - PolitiekPraat',
-    'partijmeter' => 'PartijMeter 2025: Ontdek welke partij bij je past - PolitiekPraat',
+    'partijmeter' => 'PartijMeter 2026: Ontdek welke partij bij je past - PolitiekPraat',
     'stemwijzer' => 'Gemeentelijke Stemwijzer Ede 2026 - Vergelijk partijen op 25 stellingen',
     'politiek-kompas' => 'Politiek Kompas: vergelijk standpunten per thema - PolitiekPraat',
     'partijen' => 'Overzicht Nederlandse politieke partijen - PolitiekPraat',
@@ -426,15 +426,7 @@ $jsAppVer   = file_exists($jsAppPath) ? filemtime($jsAppPath) : time();
         "@context": "https://schema.org",
         "@type": "WebSite",
         "name": "<?php echo SITENAME; ?>",
-        "url": "<?php echo URLROOT; ?>",
-        "potentialAction": {
-            "@type": "SearchAction",
-            "target": {
-                "@type": "EntryPoint",
-                "urlTemplate": "<?php echo URLROOT; ?>/zoeken?q={search_term_string}"
-            },
-            "query-input": "required name=search_term_string"
-        }
+        "url": "<?php echo URLROOT; ?>"
     }
     </script>
 


### PR DESCRIPTION
### Motivation
- Herstel de kapotte `/newsletter/unsubscribe` route die door het gebruik van een querystring in het controllerpad 404 veroorzaakte. 
- Verwijder productie-logging die mogelijk PII/headers/POST-data lekt vanuit het like-endpoint en verminderd onnodige logruis. 
- Beperk debug-logging op de nieuwspagina tot expliciete debug-sessies om logruis te voorkomen. 
- Corrigeer SEO/structured-data inconsistenties en jaarvermelding voor PartijMeter.

### Description
- Vervangt de route in `index.php` voor `newsletter/unsubscribe` door een closure die `$_GET['action'] = 'unsubscribe'` zet en daarna `controllers/newsletter.php` laadt, zodat routing op pad-niveau werkt in plaats van op een controller-pad met querystring. 
- Verwijdert expliciete debug `error_log(...)` calls, header/POST dumps en debug-responsevelden uit `views/blogs/update_likes.php`, en maakt foutberichten generiek en Nederlandstalig. 
- Plaatst de nieuwsstatistieken-`error_log` calls in `controllers/nieuws.php` achter een `if (APP_DEBUG && isset($_GET['debug']))` guard zodat ze alleen tijdens expliciete debug-sessies verschijnen. 
- Past `views/templates/header.php` aan om de PartijMeter fallback-titel naar `2026` te brengen en verwijdert de `SearchAction` JSON-LD die verwees naar de niet-bestaande `/zoeken` route terwijl de rest van de `WebSite` schema behouden blijft. 

### Testing
- Router dispatch sanity test via a small `php -r 'require "includes/Router.php"; ...'` script bevestigde dat de `newsletter/unsubscribe` route nu als callable dispatcht en `$_GET['action']` wordt gezet (geslaagd). 
- PHP lint uitgevoerd met `php -l` op de gewijzigde bestanden (en een volledige sweep via `git ls-files '*.php' | xargs -I{} php -l {}`) en gaf geen syntaxfouten (geslaagd). 
- Project smoke checks via `bash scripts/tests/ci_smoke.sh` werden uitgevoerd en slaagden (geslaagd). 
- Recent logs gecontroleerd met `tail -n 40 logs/*.log` om regressies in log-output te verifiëren; geen nieuwe productie-lekken gevonden tijdens de controles (geen issues gevonden).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05bc5337e0832990910ec8c82bf12b)